### PR TITLE
Anininjafix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     implementation 'androidx.work:work-runtime-ktx:2.10.0'
     ksp 'com.github.bumptech.glide:ksp:5.0.0-rc01'
     implementation 'com.github.bumptech.glide:okhttp3-integration:5.0.0-rc01'
+    implementation 'org.chromium.net:cronet-embedded:119.6045.31'
 
     implementation 'androidx.media3:media3-exoplayer:1.8.0'
     implementation 'androidx.media3:media3-exoplayer-dash:1.8.0'

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/home/HomeViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ import com.streamflixreborn.streamflix.models.Category
 import com.streamflixreborn.streamflix.models.Episode
 import com.streamflixreborn.streamflix.models.Movie
 import com.streamflixreborn.streamflix.models.TvShow
+import com.streamflixreborn.streamflix.providers.AnimeOnlineNinjaProvider
 import com.streamflixreborn.streamflix.providers.Provider
 import com.streamflixreborn.streamflix.ui.UserDataNotifier
 import com.streamflixreborn.streamflix.utils.HomeCacheStore
@@ -373,7 +374,10 @@ class HomeViewModel(database: AppDatabase) : ViewModel() {
         currentProvider = provider
         val appContext = StreamFlixApp.instance.applicationContext
         val cachedCategories = HomeCacheStore.read(appContext, provider)
-        if (!cachedCategories.isNullOrEmpty()) {
+        val deferCachedHomeForClearance =
+                provider === AnimeOnlineNinjaProvider &&
+                        !AnimeOnlineNinjaProvider.hasCurrentClearanceCookie()
+        if (!cachedCategories.isNullOrEmpty() && !deferCachedHomeForClearance) {
             _state.emit(State.SuccessLoading(cachedCategories))
         } else {
             _state.emit(State.Loading)
@@ -389,6 +393,8 @@ class HomeViewModel(database: AppDatabase) : ViewModel() {
             Log.e("HomeViewModel", "getHome: ", e)
             if (cachedCategories.isNullOrEmpty()) {
                 _state.emit(State.FailedLoading(e))
+            } else if (deferCachedHomeForClearance) {
+                _state.emit(State.SuccessLoading(cachedCategories))
             }
         }
     }

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/home/HomeViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/home/HomeViewModel.kt
@@ -10,7 +10,6 @@ import com.streamflixreborn.streamflix.models.Category
 import com.streamflixreborn.streamflix.models.Episode
 import com.streamflixreborn.streamflix.models.Movie
 import com.streamflixreborn.streamflix.models.TvShow
-import com.streamflixreborn.streamflix.providers.AnimeOnlineNinjaProvider
 import com.streamflixreborn.streamflix.providers.Provider
 import com.streamflixreborn.streamflix.ui.UserDataNotifier
 import com.streamflixreborn.streamflix.utils.HomeCacheStore
@@ -373,10 +372,6 @@ class HomeViewModel(database: AppDatabase) : ViewModel() {
 
         currentProvider = provider
         val appContext = StreamFlixApp.instance.applicationContext
-
-        if (provider is AnimeOnlineNinjaProvider) {
-            HomeCacheStore.clear(appContext, provider)
-        }
         val cachedCategories = HomeCacheStore.read(appContext, provider)
         if (!cachedCategories.isNullOrEmpty()) {
             _state.emit(State.SuccessLoading(cachedCategories))

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -27,6 +27,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.net.URL
+import java.net.URLDecoder
 import java.net.URLEncoder
 import java.text.Normalizer
 import java.util.concurrent.ConcurrentHashMap
@@ -308,8 +309,17 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     override suspend fun getTvShow(id: String): TvShow {
-        val url = toAbsoluteUrl(id, "/online/")
-        val document = getDocument(url)
+        val requestedUrl = toAbsoluteUrl(id, "/online/")
+        val (url, document) = if (requestedUrl.contains("/temporada/", ignoreCase = true)) {
+            val seasonDocument = getDocument(requestedUrl)
+            val parentUrl = resolveParentTvShowUrl(seasonDocument)
+                ?: throw IllegalStateException(
+                    "AnimeOnline Ninja parent TV show not found for season $requestedUrl"
+                )
+            parentUrl to getDocument(parentUrl)
+        } else {
+            requestedUrl to getDocument(requestedUrl)
+        }
         val title = document.extractDetailTitle().ifBlank { id }
         val overview = extractOverview(document, title)
         val poster = extractDetailArtwork(document, url)
@@ -336,6 +346,64 @@ object AnimeOnlineNinjaProvider : Provider {
             seasons = seasons,
             recommendations = recommendations
         )
+    }
+
+    private suspend fun resolveParentTvShowUrl(seasonDocument: Document): String? {
+        val seasonTitle = seasonDocument.extractDetailTitle()
+        val parentTitle = seasonTitle
+            .replace(
+                Regex("""\s*[-–—:]?\s*temporada\s+\d+.*$""", RegexOption.IGNORE_CASE),
+                "",
+            )
+            .trim()
+            .ifBlank { seasonTitle }
+
+        findMatchingTvShowUrl(seasonDocument, parentTitle)?.let { return it }
+
+        val query = URLEncoder.encode(parentTitle, "UTF-8")
+        val searchDocument = getDocument("$baseUrl/?s=$query")
+        return findMatchingTvShowUrl(searchDocument, parentTitle)
+    }
+
+    private fun findMatchingTvShowUrl(document: Document, parentTitle: String): String? {
+        val targetKey = titleKey(parentTitle)
+        if (targetKey.isBlank()) return null
+
+        return document.select("a[href*='/online/']")
+            .mapNotNull { link ->
+                val href = link.absUrl("href").ifBlank { link.attr("href") }
+                if (href.isBlank()) return@mapNotNull null
+
+                val labels = listOf(
+                    link.text(),
+                    link.attr("title"),
+                    link.selectFirst("img[alt]")?.attr("alt").orEmpty(),
+                    link.parent()?.text().orEmpty(),
+                    runCatching {
+                        URLDecoder.decode(normalizeId(href, "/online/"), "UTF-8")
+                            .replace('-', ' ')
+                    }.getOrDefault(""),
+                )
+                val score = labels.maxOf { label ->
+                    val candidateKey = titleKey(label)
+                    when {
+                        candidateKey == targetKey -> 100
+                        candidateKey.startsWith(targetKey) -> 80
+                        targetKey.startsWith(candidateKey) && candidateKey.length >= 6 -> 70
+                        else -> 0
+                    }
+                }
+                href to score
+            }
+            .maxByOrNull { (_, score) -> score }
+            ?.takeIf { (_, score) -> score > 0 }
+            ?.first
+    }
+
+    private fun titleKey(value: String): String {
+        return Normalizer.normalize(value.lowercase(), Normalizer.Form.NFD)
+            .replace(Regex("""\p{Mn}|\p{Cf}"""), "")
+            .replace(Regex("""[^a-z0-9]+"""), "")
     }
 
     override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
@@ -693,21 +761,24 @@ object AnimeOnlineNinjaProvider : Provider {
         ).firstOrNull { it.isNotBlank() }?.let(::cleanTitle) ?: return null
 
         return TvShow(
-            id = parentTvShowId(href, parentTitle),
+            // A season permalink is authoritative. Inferring an /online/ slug
+            // from its title can point at a show URL that does not exist.
+            id = if (href.contains("/temporada/", ignoreCase = true)) {
+                href
+            } else {
+                parentTvShowId(href, parentTitle)
+            },
             title = parentTitle,
             poster = poster
         )
     }
 
     private fun parentTvShowId(href: String, parentTitle: String): String {
-        val slug = when {
-            href.contains("/temporada/", ignoreCase = true) -> normalizeId(href, "/temporada/")
-                .replace(Regex("""-temporada-\d+$""", RegexOption.IGNORE_CASE), "")
-
-            href.contains("/episodio/", ignoreCase = true) -> normalizeId(href, "/episodio/")
+        val slug = if (href.contains("/episodio/", ignoreCase = true)) {
+            normalizeId(href, "/episodio/")
                 .replace(Regex("""-cap-\d+$""", RegexOption.IGNORE_CASE), "")
-
-            else -> ""
+        } else {
+            ""
         }
 
         return slug.ifBlank { slugify(parentTitle) }
@@ -1146,3 +1217,4 @@ private object AnimeOnlineNinjaClearanceStore {
 
     fun cookieHeader(): String? = cookieHeader
 }
+

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -23,6 +23,7 @@ import okhttp3.Request
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.json.JSONObject
+import org.json.JSONTokener
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -69,16 +70,19 @@ object AnimeOnlineNinjaProvider : Provider {
             return cached.document.clone().apply { setBaseUri(cached.finalUrl) }
         }
 
-        runCatching { fetchDocumentDirect(url) }.getOrNull()?.let { directResult ->
-            cacheDocument(url, directResult)
-            return directResult.clone()
-        }
+        runCatching { fetchDocumentDirect(url) }
+            .onFailure { error -> logFailure("direct page request", url, error) }
+            .getOrNull()
+            ?.let { directResult ->
+                cacheDocument(url, directResult)
+                return directResult.clone()
+            }
 
         val result = providerMutex.withLock {
             Log.d(TAG, "Loading page through WebView -> url=$url")
             getResolver().getResult(
                 url = url,
-                headers = pageHeaders(url),
+                headers = pageHeaders(baseUrl),
                 completion = { currentUrl, html, cookies ->
                     val challenge = requiresClearance(html) || currentUrl.contains("/cdn-cgi/", ignoreCase = true)
                     val usable = hasUsableSiteContent(html, currentUrl)
@@ -97,6 +101,47 @@ object AnimeOnlineNinjaProvider : Provider {
         return Jsoup.parse(result.html, finalUrl).apply { setBaseUri(finalUrl) }.also {
             cacheDocument(url, it)
         }
+    }
+
+    private fun promoteClearanceCookies(sourceUrl: String) {
+        val cookieManager = CookieManager.getInstance()
+        val cookieHeader = listOf(
+            sourceUrl,
+            SITE_BASE_URL,
+            "$SITE_BASE_URL/",
+            baseUrl,
+            "$baseUrl/"
+        ).firstNotNullOfOrNull { candidate ->
+            cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
+        }.orEmpty()
+
+        if (cookieHeader.isBlank()) {
+            cookieManager.flush()
+            return
+        }
+
+        val targets = listOf(
+            SITE_BASE_URL,
+            "$SITE_BASE_URL/",
+            baseUrl,
+            "$baseUrl/",
+            sourceUrl
+        ).distinct()
+
+        cookieHeader.split(";")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .forEach { cookie ->
+                val rootCookie = if (cookie.contains("Path=", ignoreCase = true)) {
+                    cookie
+                } else {
+                    "$cookie; Path=/"
+                }
+                targets.forEach { target ->
+                    cookieManager.setCookie(target, rootCookie)
+                }
+            }
+        cookieManager.flush()
     }
 
     private fun pageHeaders(referer: String): Map<String, String> {
@@ -145,46 +190,56 @@ object AnimeOnlineNinjaProvider : Provider {
         )
     }
 
-    private suspend fun fetchJson(url: String): JSONObject {
-        val body = getJsonBody(url)
+    private suspend fun fetchJson(url: String, referer: String): JSONObject {
+        val body = getJsonBody(url, referer)
         return JSONObject(body)
     }
 
-    private suspend fun getJsonBody(url: String): String {
-        runCatching { fetchJsonDirect(url) }.getOrNull()?.let { body ->
-            return body
-        }
+    private suspend fun getJsonBody(url: String, referer: String): String {
+        runCatching { fetchJsonDirect(url, referer) }
+            .onFailure { error -> logFailure("direct JSON request", url, error) }
+            .getOrNull()
+            ?.let { body ->
+                return body
+            }
 
         val result = providerMutex.withLock {
             Log.d(TAG, "Loading JSON through WebView -> url=$url")
             getResolver().getResult(
                 url = url,
-                headers = pageHeaders(url),
+                headers = pageHeaders(referer),
                 completion = { currentUrl, html, _ ->
                     val jsonBody = extractJsonBody(html)
                     val jsonReady = jsonBody.startsWith("{") || jsonBody.startsWith("[")
                     val challenge = requiresClearance(html) || currentUrl.contains("/cdn-cgi/", ignoreCase = true)
                     Log.d(TAG, "WebView JSON poll -> url=$currentUrl challenge=$challenge jsonReady=$jsonReady")
                     !challenge && jsonReady
-                }
+                },
+                valueScript = "(function(){return document.body ? document.body.innerText : document.documentElement.innerText;})()",
             )
         }
 
-        val body = extractJsonBody(result.html)
+        val evaluatedBody = decodeJavascriptValue(result.evaluatedValue).orEmpty().trim()
+        val body = evaluatedBody.takeIf { it.startsWith("{") || it.startsWith("[") }
+            ?: extractJsonBody(result.html)
 
         if (requiresClearance(body)) {
             throw ChallengeRequiredException("AnimeOnline Ninja Cloudflare challenge detected for $url")
         }
+        if (!body.startsWith("{") && !body.startsWith("[")) {
+            throw IllegalStateException("AnimeOnline Ninja returned invalid JSON for $url")
+        }
+        promoteClearanceCookies(result.finalUrl ?: url)
         return body
     }
 
-    private fun fetchJsonDirect(url: String): String? {
+    private fun fetchJsonDirect(url: String, referer: String): String? {
         val requestBuilder = Request.Builder()
             .url(url)
             .header("User-Agent", NetworkClient.USER_AGENT)
             .header("Accept", "application/json,text/plain,*/*")
             .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
-            .header("Referer", url)
+            .header("Referer", referer)
 
         currentClearanceCookie()?.takeIf { it.isNotBlank() }?.let { cookie ->
             requestBuilder.header("Cookie", cookie)
@@ -192,8 +247,14 @@ object AnimeOnlineNinjaProvider : Provider {
 
         NetworkClient.default.newCall(requestBuilder.build()).execute().use { response ->
             val body = response.body?.string().orEmpty()
-            if (!response.isSuccessful || body.isBlank()) return null
-            if (requiresClearance(body)) return null
+            if (!response.isSuccessful || body.isBlank()) {
+                Log.w(TAG, "Direct JSON rejected -> code=${response.code} url=$url")
+                return null
+            }
+            if (requiresClearance(body)) {
+                Log.w(TAG, "Direct JSON received a challenge -> url=$url")
+                return null
+            }
             val trimmed = body.trim()
             return if (trimmed.startsWith("{") || trimmed.startsWith("[")) trimmed else null
         }
@@ -208,9 +269,19 @@ object AnimeOnlineNinjaProvider : Provider {
         return Jsoup.parse(preBody ?: html).text().trim()
     }
 
+    private fun decodeJavascriptValue(value: String?): String? {
+        val encoded = value?.trim()?.takeIf { it.isNotEmpty() && it != "null" } ?: return null
+        return when (val decoded = runCatching { JSONTokener(encoded).nextValue() }.getOrNull()) {
+            is String -> decoded
+            null -> null
+            else -> decoded.toString()
+        }
+    }
+
     override suspend fun getHome(): List<Category> {
         val document = getDocument("$baseUrl/inicio/")
-        return parseHomeCategories(document)
+        return parseHomeCategories(document).takeIf { it.isNotEmpty() }
+            ?: throw IllegalStateException("AnimeOnline Ninja home page contained no recognizable categories")
     }
 
     override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
@@ -317,9 +388,7 @@ object AnimeOnlineNinjaProvider : Provider {
             if (href.isBlank()) return@mapIndexedNotNull null
 
             val numberText = element.selectFirst(".numerando, .num, .numero")?.text()?.trim().orEmpty()
-            val number = numberText.substringBefore("-").trim().toIntOrNull()
-                ?: Regex("""\d+""").find(numberText)?.value?.toIntOrNull()
-                ?: (index + 1)
+            val number = parseEpisodeNumber(numberText, index + 1)
 
             val title = link.text().trim().ifBlank {
                 element.selectFirst(".episodiotitle, .title, h3")?.text()?.trim().orEmpty()
@@ -373,29 +442,49 @@ object AnimeOnlineNinjaProvider : Provider {
             is Video.Type.Episode -> toAbsoluteUrl(id, "/episodio/")
         }
 
-        val document = runCatching { getDocument(pageUrl) }.getOrNull()
-        val postId = resolvePostId(pageUrl, document, videoType)
-            ?: return emptyList()
-
-        val type = when (videoType) {
+        val document = runCatching { getDocument(pageUrl) }
+            .onFailure { error -> logFailure("player page request", pageUrl, error) }
+            .getOrElse { error -> throw IllegalStateException("Unable to load player page $pageUrl", error) }
+        val fallbackType = when (videoType) {
             is Video.Type.Movie -> "movie"
             is Video.Type.Episode -> "tv"
         }
+        val discoveredSources = parsePlayerSources(document, fallbackType)
+        val postId = discoveredSources.firstOrNull()?.postId ?: resolvePostId(pageUrl, document)
+        ?: throw IllegalStateException("AnimeOnline Ninja post id not found for $pageUrl")
+        val sources = discoveredSources.ifEmpty {
+            Log.w(TAG, "No player source metadata found; using compatibility probe -> post=$postId")
+            (1..5).map { source ->
+                PlayerSource(
+                    postId = postId,
+                    type = fallbackType,
+                    number = source,
+                    label = "Server $source",
+                )
+            }
+        }
 
         val collected = linkedMapOf<String, Video.Server>()
-        for (source in 1..5) {
-            val apiUrl = "$baseUrl/wp-json/dooplayer/v1/post/$postId?type=$type&source=$source"
-            val json = runCatching { fetchJson(apiUrl) }.getOrNull() ?: continue
-            val embedUrl = json.optString("embed_url").trim()
-            if (embedUrl.isBlank() || !embedUrl.startsWith("http")) continue
+        for (source in sources) {
+            val apiUrl = "$baseUrl/wp-json/dooplayer/v1/post/${source.postId}?type=${source.type}&source=${source.number}"
+            val json = runCatching { fetchJson(apiUrl, referer = pageUrl) }
+                .onFailure { error -> logFailure("player source ${source.number}", apiUrl, error) }
+                .getOrNull() ?: continue
+            val embedUrl = normalizeExternalUrl(json.optString("embed_url"), baseUrl)
+            if (embedUrl == null) {
+                Log.w(TAG, "Player source returned no embed URL -> source=${source.number} post=${source.postId}")
+                continue
+            }
 
-            val servers = runCatching { resolveServers(embedUrl, source) }.getOrDefault(emptyList())
+            val servers = runCatching { resolveServers(embedUrl, source.number, pageUrl) }
+                .onFailure { error -> logFailure("embed resolution", embedUrl, error) }
+                .getOrDefault(emptyList())
             if (servers.isEmpty()) {
                 collected.putIfAbsent(
                     embedUrl,
                     Video.Server(
                         id = embedUrl,
-                        name = hostLabel(embedUrl, source),
+                        name = source.label.ifBlank { hostLabel(embedUrl, source.number) },
                         src = embedUrl
                     )
                 )
@@ -406,10 +495,45 @@ object AnimeOnlineNinjaProvider : Provider {
             }
         }
 
+        if (collected.isEmpty()) {
+            directPlayerEmbeds(document).forEachIndexed { index, embedUrl ->
+                collected.putIfAbsent(
+                    embedUrl,
+                    Video.Server(
+                        id = embedUrl,
+                        name = hostLabel(embedUrl, index + 1),
+                        src = embedUrl,
+                    ),
+                )
+            }
+        }
+
+        if (collected.isEmpty()) {
+            Log.w(TAG, "No playable servers found -> page=$pageUrl sources=${sources.size}")
+        }
         return prioritizeServers(collected.values.toList())
     }
 
-    private suspend fun resolvePostId(pageUrl: String, document: Document?, videoType: Video.Type): String? {
+    private fun parsePlayerSources(document: Document, fallbackType: String): List<PlayerSource> {
+        return document.select(
+            "#playeroptionsul [data-nume], li.dooplay_player_option[data-nume], [data-post][data-nume][data-type]",
+        ).mapNotNull { element ->
+            val number = element.attr("data-nume").toIntOrNull() ?: return@mapNotNull null
+            val postId = element.attr("data-post").trim()
+                .takeIf { it.isNotEmpty() && it.all(Char::isDigit) }
+                ?: return@mapNotNull null
+            val type = element.attr("data-type").trim().ifBlank { fallbackType }
+            val label = element.selectFirst(".title, span.title, .server, span")
+                ?.text()
+                ?.trim()
+                .orEmpty()
+                .ifBlank { "Server $number" }
+
+            PlayerSource(postId, type, number, label)
+        }.distinctBy { source -> "${source.postId}:${source.type}:${source.number}" }
+    }
+
+    private fun resolvePostId(pageUrl: String, document: Document?): String? {
         Regex("""[?&]p=(\d+)""").find(pageUrl)?.groupValues?.getOrNull(1)?.let { return it }
 
         if (document != null) {
@@ -429,6 +553,33 @@ object AnimeOnlineNinjaProvider : Provider {
 
         return null
     }
+
+    private fun directPlayerEmbeds(document: Document): List<String> {
+        return document.select(
+            "#dooplay_player_response iframe[src], #playeroptions iframe[src], .player_sist iframe[src], .playex iframe[src]",
+        ).mapNotNull { element ->
+            normalizeExternalUrl(element.absUrl("src").ifBlank { element.attr("src") }, document.baseUri())
+        }.distinct()
+    }
+
+    private fun normalizeExternalUrl(value: String?, referer: String): String? {
+        val url = value?.trim().orEmpty()
+        if (url.isBlank() || url.equals("about:blank", ignoreCase = true)) return null
+        return runCatching {
+            when {
+                url.startsWith("//") -> "https:$url"
+                url.startsWith("http://", true) || url.startsWith("https://", true) -> url
+                else -> URL(URL(referer), url).toString()
+            }
+        }.getOrNull()
+    }
+
+    private data class PlayerSource(
+        val postId: String,
+        val type: String,
+        val number: Int,
+        val label: String,
+    )
 
     override suspend fun getVideo(server: Video.Server): Video {
         return Extractor.extract(server.src.ifBlank { server.id }, server)
@@ -708,9 +859,7 @@ object AnimeOnlineNinjaProvider : Provider {
                     if (href.isBlank()) return@mapIndexedNotNull null
 
                     val numberText = element.selectFirst(".numerando, .num, .numero")?.text()?.trim().orEmpty()
-                    val number = numberText.substringBefore("-").trim().toIntOrNull()
-                        ?: Regex("""\d+""").find(numberText)?.value?.toIntOrNull()
-                        ?: (epIndex + 1)
+                    val number = parseEpisodeNumber(numberText, epIndex + 1)
 
                     Episode(
                         id = href,
@@ -732,6 +881,17 @@ object AnimeOnlineNinjaProvider : Provider {
                 episodes = episodes
             )
         }.sortedBy { it.number }
+    }
+
+    private fun parseEpisodeNumber(numberText: String, fallback: Int): Int {
+        val numbers = Regex("""\d+""")
+            .findAll(numberText)
+            .mapNotNull { match -> match.value.toIntOrNull() }
+            .toList()
+
+        // DooPlay commonly renders this as "season - episode" (for example
+        // "1 - 8"). The final component is therefore the episode number.
+        return numbers.lastOrNull()?.takeIf { it > 0 } ?: fallback
     }
 
     private fun toAbsoluteUrl(id: String, preferredPrefix: String? = null): String {
@@ -762,22 +922,27 @@ object AnimeOnlineNinjaProvider : Provider {
         }.getOrNull() ?: "Server $source"
     }
 
-    private suspend fun resolveServers(embedUrl: String, source: Int): List<Video.Server> {
+    private suspend fun resolveServers(embedUrl: String, source: Int, pageUrl: String): List<Video.Server> {
         val html = providerMutex.withLock {
-            getResolver().get(embedUrl, mapOf("Referer" to "$baseUrl/"))
+            getResolver().get(
+                embedUrl,
+                mapOf(
+                    "Referer" to pageUrl,
+                    "User-Agent" to NetworkClient.USER_AGENT,
+                ),
+            )
         }
         val document = Jsoup.parse(html, embedUrl)
         val servers = linkedMapOf<String, Video.Server>()
 
         document.select("li[onclick*='go_to_player']").forEachIndexed { index, element ->
             val onclick = element.attr("onclick")
-            val serverUrl = Regex("""go_to_player\('([^']+)'\)""")
+            val serverUrl = Regex("""go_to_player\s*\(\s*['\"]([^'\"]+)['\"]\s*\)""")
                 .find(onclick)
                 ?.groupValues
                 ?.getOrNull(1)
-                ?.trim()
-                .orEmpty()
-            if (serverUrl.isBlank()) return@forEachIndexed
+                ?.let { normalizeExternalUrl(it, embedUrl) }
+                ?: return@forEachIndexed
 
             val label = element.selectFirst("span")?.text()?.trim().orEmpty()
                 .ifBlank { hostLabel(serverUrl, index + 1) }
@@ -800,10 +965,32 @@ object AnimeOnlineNinjaProvider : Provider {
             )
         }
 
+        document.select("li[data-link], li[data-url], .server[data-link], .server[data-url]")
+            .forEachIndexed { index, element ->
+                val serverUrl = normalizeExternalUrl(
+                    element.attr("data-link").ifBlank { element.attr("data-url") },
+                    embedUrl,
+                ) ?: return@forEachIndexed
+                val label = element.selectFirst(".title, span")?.text()?.trim()
+                    .orEmpty()
+                    .ifBlank { hostLabel(serverUrl, index + 1) }
+
+                servers.putIfAbsent(
+                    serverUrl,
+                    Video.Server(
+                        id = serverUrl,
+                        name = label,
+                        src = serverUrl,
+                    ),
+                )
+            }
+
         if (servers.isEmpty()) {
             document.select("iframe[src]").forEachIndexed { index, element ->
-                val serverUrl = element.absUrl("src").ifBlank { element.attr("src") }.trim()
-                if (serverUrl.isBlank()) return@forEachIndexed
+                val serverUrl = normalizeExternalUrl(
+                    element.absUrl("src").ifBlank { element.attr("src") },
+                    embedUrl,
+                ) ?: return@forEachIndexed
 
                 servers.putIfAbsent(
                     serverUrl,
@@ -847,7 +1034,9 @@ object AnimeOnlineNinjaProvider : Provider {
         return html.contains("cf-browser-verification", ignoreCase = true) ||
                 html.contains("Just a moment...", ignoreCase = true) ||
                 html.contains("Checking your browser", ignoreCase = true) ||
-                (html.contains("cloudflare", ignoreCase = true) && !html.contains("wp-json/dooplayer", ignoreCase = true))
+                html.contains("/cdn-cgi/challenge-platform/", ignoreCase = true) ||
+                html.contains("cf-chl-", ignoreCase = true) ||
+                html.contains("challenge-form", ignoreCase = true)
     }
 
     private fun itemKey(item: AppAdapter.Item): String {
@@ -859,57 +1048,7 @@ object AnimeOnlineNinjaProvider : Provider {
         }
 
     }
-    private fun promoteClearanceCookies(sourceUrl: String) {
-        val cookieManager = CookieManager.getInstance()
-        val cookieHeader = listOf(
-            sourceUrl,
-            SITE_BASE_URL,
-            "$SITE_BASE_URL/",
-            baseUrl,
-            "$baseUrl/"
-        ).firstNotNullOfOrNull { candidate ->
-            cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
-        }.orEmpty()
-
-        if (cookieHeader.isBlank()) {
-            cookieManager.flush()
-            return
-        }
-
-        promoteClearanceCookieHeader(cookieHeader)
-
-        val targets = listOf(
-            SITE_BASE_URL,
-            "$SITE_BASE_URL/",
-            baseUrl,
-            "$baseUrl/",
-            sourceUrl
-        ).distinct()
-
-        cookieHeader.split(";")
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .forEach { cookie ->
-                val rootCookie = if (cookie.contains("Path=", ignoreCase = true)) {
-                    cookie
-                } else {
-                    "$cookie; Path=/"
-                }
-                targets.forEach { target ->
-                    cookieManager.setCookie(target, rootCookie)
-                }
-        }
-        cookieManager.flush()
-    }
-
     private fun currentClearanceCookie(): String? {
-        AnimeOnlineNinjaClearanceStore.cookieHeader()?.takeIf { it.isNotBlank() }?.let {
-            clearanceCookieHeader = it
-            return it
-        }
-
-        clearanceCookieHeader?.takeIf { it.isNotBlank() }?.let { return it }
-
         val cookieManager = CookieManager.getInstance()
         val candidates = listOf(
             "$SITE_BASE_URL/",
@@ -918,12 +1057,19 @@ object AnimeOnlineNinjaProvider : Provider {
             baseUrl
         )
 
-        return candidates.firstNotNullOfOrNull { candidate ->
+        candidates.firstNotNullOfOrNull { candidate ->
             cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
         }?.also {
             clearanceCookieHeader = it
             AnimeOnlineNinjaClearanceStore.update(it)
+        }?.let { return it }
+
+        AnimeOnlineNinjaClearanceStore.cookieHeader()?.takeIf { it.isNotBlank() }?.let {
+            clearanceCookieHeader = it
+            return it
         }
+
+        return clearanceCookieHeader?.takeIf { it.isNotBlank() }
     }
 
     fun clearanceCookieForGlide(): String? {
@@ -936,7 +1082,7 @@ object AnimeOnlineNinjaProvider : Provider {
             .header("User-Agent", NetworkClient.USER_AGENT)
             .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
             .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
-            .header("Referer", url)
+            .header("Referer", baseUrl)
 
         currentClearanceCookie()?.takeIf { it.isNotBlank() }?.let { cookie ->
             requestBuilder.header("Cookie", cookie)
@@ -944,10 +1090,16 @@ object AnimeOnlineNinjaProvider : Provider {
 
         NetworkClient.default.newCall(requestBuilder.build()).execute().use { response ->
             val body = response.body?.string().orEmpty()
-            if (!response.isSuccessful || body.isBlank()) return null
-            if (requiresClearance(body) || !hasUsableSiteContent(body, url)) return null
+            if (!response.isSuccessful || body.isBlank()) {
+                Log.w(TAG, "Direct page rejected -> code=${response.code} url=$url")
+                return null
+            }
 
             val finalUrl = response.request.url.toString()
+            if (requiresClearance(body) || !hasUsableSiteContent(body, finalUrl)) {
+                Log.w(TAG, "Direct page was challenged or incomplete -> url=$finalUrl size=${body.length}")
+                return null
+            }
             return Jsoup.parse(body, finalUrl).apply { setBaseUri(finalUrl) }
         }
     }
@@ -971,8 +1123,15 @@ object AnimeOnlineNinjaProvider : Provider {
 
     private fun promoteClearanceCookieHeader(cookieHeader: String?) {
         val normalized = cookieHeader?.trim()?.takeIf { it.isNotBlank() } ?: return
+        if (normalized != clearanceCookieHeader) {
+            documentCache.clear()
+        }
         clearanceCookieHeader = normalized
         AnimeOnlineNinjaClearanceStore.update(normalized)
+    }
+
+    private fun logFailure(operation: String, url: String, error: Throwable) {
+        Log.w(TAG, "$operation failed -> url=$url type=${error.javaClass.simpleName} message=${error.message}")
     }
 
     private data class CachedDocument(

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -310,11 +310,13 @@ object AnimeOnlineNinjaProvider : Provider {
 
     override suspend fun getTvShow(id: String): TvShow {
         val requestedUrl = toAbsoluteUrl(id, "/online/")
-        val (url, document) = if (requestedUrl.contains("/temporada/", ignoreCase = true)) {
-            val seasonDocument = getDocument(requestedUrl)
-            val parentUrl = resolveParentTvShowUrl(seasonDocument)
+        val isParentLookup = requestedUrl.contains("/temporada/", ignoreCase = true) ||
+                requestedUrl.contains("/episodio/", ignoreCase = true)
+        val (url, document) = if (isParentLookup) {
+            val sourceDocument = getDocument(requestedUrl)
+            val parentUrl = resolveParentTvShowUrl(sourceDocument)
                 ?: throw IllegalStateException(
-                    "AnimeOnline Ninja parent TV show not found for season $requestedUrl"
+                    "AnimeOnline Ninja parent TV show not found for $requestedUrl"
                 )
             parentUrl to getDocument(parentUrl)
         } else {
@@ -348,17 +350,30 @@ object AnimeOnlineNinjaProvider : Provider {
         )
     }
 
-    private suspend fun resolveParentTvShowUrl(seasonDocument: Document): String? {
-        val seasonTitle = seasonDocument.extractDetailTitle()
-        val parentTitle = seasonTitle
+    private suspend fun resolveParentTvShowUrl(sourceDocument: Document): String? {
+        sourceDocument.select(".pag_episodes .item a[href]")
+            .firstOrNull { link ->
+                link.text().contains("lista de episodios", ignoreCase = true) &&
+                        link.attr("href").contains("/online/", ignoreCase = true)
+            }
+            ?.let { link -> link.absUrl("href").ifBlank { link.attr("href") } }
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        val sourceTitle = sourceDocument.extractDetailTitle()
+        val parentTitle = cleanTitle(sourceTitle)
             .replace(
-                Regex("""\s*[-–—:]?\s*temporada\s+\d+.*$""", RegexOption.IGNORE_CASE),
+                Regex(
+                    """\s*[-–—:]?\s*(?:temporada|episodio|cap[ií]tulo|cap)\s*\d+.*$""",
+                    RegexOption.IGNORE_CASE,
+                ),
                 "",
             )
+            .replace(Regex("""\s*[-–—:]?\s*\d+\s*[x×]\s*\d+.*$""", RegexOption.IGNORE_CASE), "")
             .trim()
-            .ifBlank { seasonTitle }
+            .ifBlank { cleanTitle(sourceTitle) }
 
-        findMatchingTvShowUrl(seasonDocument, parentTitle)?.let { return it }
+        findMatchingTvShowUrl(sourceDocument, parentTitle)?.let { return it }
 
         val query = URLEncoder.encode(parentTitle, "UTF-8")
         val searchDocument = getDocument("$baseUrl/?s=$query")
@@ -761,27 +776,12 @@ object AnimeOnlineNinjaProvider : Provider {
         ).firstOrNull { it.isNotBlank() }?.let(::cleanTitle) ?: return null
 
         return TvShow(
-            // A season permalink is authoritative. Inferring an /online/ slug
-            // from its title can point at a show URL that does not exist.
-            id = if (href.contains("/temporada/", ignoreCase = true)) {
-                href
-            } else {
-                parentTvShowId(href, parentTitle)
-            },
+            // Season and episode permalinks are authoritative lookup sources.
+            // Their parent /online/ URL is resolved when the card is opened.
+            id = href,
             title = parentTitle,
             poster = poster
         )
-    }
-
-    private fun parentTvShowId(href: String, parentTitle: String): String {
-        val slug = if (href.contains("/episodio/", ignoreCase = true)) {
-            normalizeId(href, "/episodio/")
-                .replace(Regex("""-cap-\d+$""", RegexOption.IGNORE_CASE), "")
-        } else {
-            ""
-        }
-
-        return slug.ifBlank { slugify(parentTitle) }
     }
 
     private fun cleanTitle(value: String): String {
@@ -858,14 +858,6 @@ object AnimeOnlineNinjaProvider : Provider {
                 }
             }
             .orEmpty()
-    }
-
-    private fun slugify(value: String): String {
-        val normalized = Normalizer.normalize(value.lowercase(), Normalizer.Form.NFD)
-            .replace(Regex("""\p{Mn}+"""), "")
-            .replace(Regex("""[^a-z0-9]+"""), "-")
-            .trim('-')
-        return normalized.ifBlank { value.lowercase().replace(Regex("""\s+"""), "-").trim('-') }
     }
 
     private fun parseSeasons(document: Document, pageUrl: String, poster: String?): List<Season> {
@@ -1217,4 +1209,3 @@ private object AnimeOnlineNinjaClearanceStore {
 
     fun cookieHeader(): String? = cookieHeader
 }
-

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -767,9 +767,9 @@ object AnimeOnlineNinjaProvider : Provider {
 
     private fun parseParentTvShow(element: Element, href: String, poster: String?): TvShow? {
         val parentTitle = listOfNotNull(
-            element.selectFirst(".season_m .c")?.text()?.trim(),
+            element.selectFirst("img[alt]")?.attr("alt")?.substringBefore(" Temporada")?.substringBefore(" Cap")?.trim(),
             element.selectFirst(".data h3")?.text()?.trim(),
-            element.selectFirst("img[alt]")?.attr("alt")?.substringBefore(" Temporada")?.substringBefore(" Cap")?.trim()
+            element.selectFirst(".season_m .c")?.text()?.trim()
         ).firstOrNull { it.isNotBlank() }?.let(::cleanTitle) ?: return null
 
         return TvShow(

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -20,7 +20,12 @@ import com.streamflixreborn.streamflix.utils.ArtworkRequestHeaders
 import com.streamflixreborn.streamflix.utils.NetworkClient
 import com.streamflixreborn.streamflix.utils.WebViewResolver
 import com.streamflixreborn.streamflix.utils.UserPreferences
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.sync.withLock
 import org.json.JSONObject
 import org.jsoup.Jsoup
@@ -268,8 +273,57 @@ object AnimeOnlineNinjaProvider : Provider {
 
     override suspend fun getHome(): List<Category> {
         val document = getDocument("$baseUrl/inicio/")
-        return parseHomeCategories(document).takeIf { it.isNotEmpty() }
+        val categories = parseHomeCategories(document).takeIf { it.isNotEmpty() }
             ?: throw IllegalStateException("AnimeOnline Ninja home page contained no recognizable categories")
+        return resolveHomeEpisodeTvShows(categories)
+    }
+
+    /**
+     * The site's latest-episode cards link to an episode and use a landscape
+     * frame from that episode. Resolve those cards before exposing the home
+     * catalog so the app always receives the canonical show id and show cover.
+     */
+    private suspend fun resolveHomeEpisodeTvShows(categories: List<Category>): List<Category> = coroutineScope {
+        val episodeCards = categories
+            .flatMap { it.list }
+            .filterIsInstance<TvShow>()
+            .filter { it.id.contains("/episodio/", ignoreCase = true) }
+
+        if (episodeCards.isEmpty()) return@coroutineScope categories
+
+        val requestLimit = Semaphore(4)
+        val resolvedByTitle = episodeCards
+            .distinctBy { titleKey(it.title) }
+            .map { episodeCard ->
+                async {
+                    val resolved = runCatching {
+                        requestLimit.withPermit { getTvShow(episodeCard.id) }
+                    }.onFailure { error ->
+                        Log.w(
+                            TAG,
+                            "Unable to resolve home episode ${episodeCard.id} to its TV show",
+                            error,
+                        )
+                    }.getOrNull()
+                    titleKey(episodeCard.title) to resolved
+                }
+            }
+            .awaitAll()
+            .toMap()
+
+        categories.map { category ->
+            category.copy(
+                list = category.list
+                    .map { item ->
+                        if (item is TvShow && item.id.contains("/episodio/", ignoreCase = true)) {
+                            resolvedByTitle[titleKey(item.title)] ?: item
+                        } else {
+                            item
+                        }
+                    }
+                    .distinctBy(::itemKey),
+            )
+        }
     }
 
     override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
@@ -282,6 +336,7 @@ object AnimeOnlineNinjaProvider : Provider {
                 Genre("live-action", "Live action"),
                 Genre("tendencias", "Popular en la web"),
                 Genre("ratings", "Mejores valorados"),
+                Genre("sin-censura", "Sin censura"),
                 Genre("award-winning-anime", "Ganadores de premios"),
                 Genre("accion", "Accion"),
                 Genre("aventura", "Aventura"),
@@ -726,6 +781,9 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private fun parseSearchItems(document: Document): List<AppAdapter.Item> {
+        // Search pages also render unrelated recommendations in the right sidebar.
+        // Only result cards inside the dedicated search result container belong to
+        // the submitted query.
         return document
             .select(".search-page > .result-item > article, .search-page .result-item article")
             .mapNotNull(::parseListingItem)
@@ -733,6 +791,9 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private fun parseGenreItems(document: Document): List<AppAdapter.Item> {
+        // Genre archives paginate their main grid at /page/{n}/. Scoping the
+        // parser to that grid makes every requested page independent from the
+        // sidebar modules that are repeated on all archive pages.
         val grid = document.selectFirst(".module > .content.right > .items")
             ?: document.selectFirst(".module .content.right .items")
             ?: return emptyList()

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -459,11 +459,8 @@ object AnimeOnlineNinjaProvider : Provider {
 
     override suspend fun getGenre(id: String, page: Int): Genre {
         val slug = id.trim().trim('/')
-        val url = if (page <= 1) {
-            "$baseUrl/genero/$slug/"
-        } else {
-            "$baseUrl/genero/$slug/page/$page/"
-        }
+        val path = if (slug == "tendencias" || slug == "ratings") slug else "genero/$slug"
+        val url = if (page <= 1) "$baseUrl/$path/" else "$baseUrl/$path/page/$page/"
 
         val document = getDocument(url)
         val title = document.selectFirst("h1")?.text()?.trim()

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -15,15 +15,14 @@ import com.streamflixreborn.streamflix.models.Season
 import com.streamflixreborn.streamflix.models.Show
 import com.streamflixreborn.streamflix.models.TvShow
 import com.streamflixreborn.streamflix.models.Video
+import com.streamflixreborn.streamflix.utils.AnimeOnlineNinjaCronetClient
 import com.streamflixreborn.streamflix.utils.ArtworkRequestHeaders
 import com.streamflixreborn.streamflix.utils.NetworkClient
 import com.streamflixreborn.streamflix.utils.WebViewResolver
 import com.streamflixreborn.streamflix.utils.UserPreferences
-import okhttp3.Request
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.json.JSONObject
-import org.json.JSONTokener
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -45,6 +44,7 @@ object AnimeOnlineNinjaProvider : Provider {
 
     private const val TAG = "AnimeOnlineNinja"
     private const val MAIN_HOST = "ww3.animeonline.ninja"
+    internal val cronetHost: String get() = MAIN_HOST
     private const val DOCUMENT_CACHE_TTL_MS = 2 * 60 * 1000L
 
     private val providerMutex = Mutex()
@@ -55,6 +55,11 @@ object AnimeOnlineNinjaProvider : Provider {
 
     fun init(context: Context) {
         webViewResolver = WebViewResolver(context)
+        AnimeOnlineNinjaCronetClient.init(context)
+    }
+
+    fun reload() {
+        documentCache.clear()
     }
 
     private fun getResolver(): WebViewResolver {
@@ -63,85 +68,25 @@ object AnimeOnlineNinjaProvider : Provider {
         }
     }
 
-    private class ChallengeRequiredException(message: String) : IllegalStateException(message)
+    private class ChallengeRequiredException(
+        message: String,
+        val rejectedClearance: String?,
+    ) : IllegalStateException(message)
 
     private suspend fun getDocument(url: String): Document {
         cachedDocument(url)?.let { cached ->
             return cached.document.clone().apply { setBaseUri(cached.finalUrl) }
         }
 
-        runCatching { fetchDocumentDirect(url) }
-            .onFailure { error -> logFailure("direct page request", url, error) }
-            .getOrNull()
-            ?.let { directResult ->
-                cacheDocument(url, directResult)
-                return directResult.clone()
-            }
-
-        val result = providerMutex.withLock {
-            Log.d(TAG, "Loading page through WebView -> url=$url")
-            getResolver().getResult(
-                url = url,
-                headers = pageHeaders(baseUrl),
-                completion = { currentUrl, html, cookies ->
-                    val challenge = requiresClearance(html) || currentUrl.contains("/cdn-cgi/", ignoreCase = true)
-                    val usable = hasUsableSiteContent(html, currentUrl)
-                    promoteClearanceCookieHeader(cookies)
-                    Log.d(TAG, "WebView page poll -> url=$currentUrl challenge=$challenge usable=$usable")
-                    !challenge && usable
-                }
-            )
+        val document = try {
+            fetchDocumentDirect(url)
+        } catch (challenge: ChallengeRequiredException) {
+            solveCloudflareChallenge(url, baseUrl, challenge.rejectedClearance)
+            fetchDocumentDirect(url)
         }
 
-        val finalUrl = result.finalUrl ?: url
-        if (requiresClearance(result.html) || !hasUsableSiteContent(result.html, finalUrl)) {
-            throw ChallengeRequiredException("AnimeOnline Ninja WebView did not reach usable content for $url")
-        }
-        promoteClearanceCookies(finalUrl)
-        return Jsoup.parse(result.html, finalUrl).apply { setBaseUri(finalUrl) }.also {
-            cacheDocument(url, it)
-        }
-    }
-
-    private fun promoteClearanceCookies(sourceUrl: String) {
-        val cookieManager = CookieManager.getInstance()
-        val cookieHeader = listOf(
-            sourceUrl,
-            SITE_BASE_URL,
-            "$SITE_BASE_URL/",
-            baseUrl,
-            "$baseUrl/"
-        ).firstNotNullOfOrNull { candidate ->
-            cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
-        }.orEmpty()
-
-        if (cookieHeader.isBlank()) {
-            cookieManager.flush()
-            return
-        }
-
-        val targets = listOf(
-            SITE_BASE_URL,
-            "$SITE_BASE_URL/",
-            baseUrl,
-            "$baseUrl/",
-            sourceUrl
-        ).distinct()
-
-        cookieHeader.split(";")
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .forEach { cookie ->
-                val rootCookie = if (cookie.contains("Path=", ignoreCase = true)) {
-                    cookie
-                } else {
-                    "$cookie; Path=/"
-                }
-                targets.forEach { target ->
-                    cookieManager.setCookie(target, rootCookie)
-                }
-            }
-        cookieManager.flush()
+        return document?.also { cacheDocument(url, it) }?.clone()
+            ?: throw IllegalStateException("AnimeOnline Ninja Cronet returned no usable page for $url")
     }
 
     private fun pageHeaders(referer: String): Map<String, String> {
@@ -168,6 +113,72 @@ object AnimeOnlineNinjaProvider : Provider {
                 html.contains("episodios", ignoreCase = true) ||
                 html.contains("post-", ignoreCase = true)
     }
+    private suspend fun solveCloudflareChallenge(
+        url: String,
+        referer: String,
+        rejectedClearance: String?,
+    ) {
+        providerMutex.withLock {
+            val currentClearance = clearanceToken(currentClearanceCookie())
+            if (!currentClearance.isNullOrBlank() && currentClearance != rejectedClearance) {
+                Log.d(TAG, "Another request already renewed Cloudflare clearance; skipping WebView")
+                return@withLock
+            }
+
+            clearStaleClearanceCookie()
+            Log.d(TAG, "Solving confirmed Cloudflare challenge in WebView -> url=$url")
+            getResolver().getResult(
+                url = url,
+                headers = pageHeaders(referer).minus("Cookie"),
+                completion = { currentUrl, _, cookies ->
+                    val newClearance = clearanceToken(cookies)
+                    val hasClearance = !newClearance.isNullOrBlank() && newClearance != currentClearance
+                    if (hasClearance) promoteClearanceCookieHeader(cookies)
+                    Log.d(TAG, "WebView challenge poll -> url=$currentUrl clearance=$hasClearance")
+                    hasClearance
+                },
+                shouldAllowNavigation = { targetUrl, _ ->
+                    runCatching {
+                        val target = URL(targetUrl)
+                        target.host.equals(MAIN_HOST, ignoreCase = true) ||
+                                target.path.contains("/cdn-cgi/", ignoreCase = true)
+                    }.getOrDefault(false)
+                },
+            )
+        }
+
+        if (clearanceToken(currentClearanceCookie()).isNullOrBlank()) {
+            throw ChallengeRequiredException(
+                message = "Cloudflare clearance was not obtained for $url",
+                rejectedClearance = rejectedClearance,
+            )
+        }
+    }
+
+    private fun clearanceToken(cookieHeader: String?): String? {
+        return cookieHeader
+            ?.split(';')
+            ?.map(String::trim)
+            ?.firstOrNull { it.startsWith("cf_clearance=", ignoreCase = true) }
+            ?.substringAfter('=')
+            ?.takeIf(String::isNotBlank)
+    }
+
+    private fun clearStaleClearanceCookie() {
+        val cookieManager = CookieManager.getInstance()
+        listOf(SITE_BASE_URL, "$SITE_BASE_URL/").forEach { target ->
+            cookieManager.setCookie(target, "cf_clearance=; Max-Age=0; Path=/; Secure")
+        }
+        cookieManager.flush()
+
+        clearanceCookieHeader = clearanceCookieHeader
+            ?.split(';')
+            ?.map(String::trim)
+            ?.filterNot { it.startsWith("cf_clearance=", ignoreCase = true) }
+            ?.joinToString("; ")
+            ?.takeIf(String::isNotBlank)
+        AnimeOnlineNinjaClearanceStore.update(clearanceCookieHeader)
+    }
 
     private fun artworkUrl(url: String?, referer: String = baseUrl): String? {
         val image = url?.trim().orEmpty()
@@ -179,6 +190,11 @@ object AnimeOnlineNinjaProvider : Provider {
             image.startsWith("/") -> "$baseUrl$image"
             else -> "$baseUrl/$image"
         }
+
+        val isProviderArtwork = runCatching {
+            URL(normalized).host.equals(MAIN_HOST, ignoreCase = true)
+        }.getOrDefault(false)
+        if (!isProviderArtwork) return normalized
 
         return ArtworkRequestHeaders.withHeaders(
             url = normalized,
@@ -196,86 +212,38 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private suspend fun getJsonBody(url: String, referer: String): String {
-        runCatching { fetchJsonDirect(url, referer) }
-            .onFailure { error -> logFailure("direct JSON request", url, error) }
-            .getOrNull()
-            ?.let { body ->
-                return body
-            }
+        val body = try {
+            fetchJsonDirect(url, referer)
+        } catch (challenge: ChallengeRequiredException) {
+            solveCloudflareChallenge(url, referer, challenge.rejectedClearance)
+            fetchJsonDirect(url, referer)
+        }
 
-        val result = providerMutex.withLock {
-            Log.d(TAG, "Loading JSON through WebView -> url=$url")
-            getResolver().getResult(
-                url = url,
-                headers = pageHeaders(referer),
-                completion = { currentUrl, html, _ ->
-                    val jsonBody = extractJsonBody(html)
-                    val jsonReady = jsonBody.startsWith("{") || jsonBody.startsWith("[")
-                    val challenge = requiresClearance(html) || currentUrl.contains("/cdn-cgi/", ignoreCase = true)
-                    Log.d(TAG, "WebView JSON poll -> url=$currentUrl challenge=$challenge jsonReady=$jsonReady")
-                    !challenge && jsonReady
-                },
-                valueScript = "(function(){return document.body ? document.body.innerText : document.documentElement.innerText;})()",
+        return body ?: throw IllegalStateException("AnimeOnline Ninja Cronet returned invalid JSON for $url")
+    }
+
+    private suspend fun fetchJsonDirect(url: String, referer: String): String? {
+        val headers = pageHeaders(referer) + ("Accept" to "application/json,text/plain,*/*")
+        val response = AnimeOnlineNinjaCronetClient.get(
+            context = StreamFlixApp.instance,
+            url = url,
+            headers = headers,
+            useCache = false,
+        )
+        val body = response.bodyAsString()
+        if (requiresClearance(body) || response.finalUrl.contains("/cdn-cgi/", ignoreCase = true)) {
+            Log.w(TAG, "Cronet JSON received a challenge -> url=$url")
+            throw ChallengeRequiredException(
+                message = "AnimeOnline Ninja Cloudflare challenge detected for $url",
+                rejectedClearance = clearanceToken(headers["Cookie"]),
             )
         }
-
-        val evaluatedBody = decodeJavascriptValue(result.evaluatedValue).orEmpty().trim()
-        val body = evaluatedBody.takeIf { it.startsWith("{") || it.startsWith("[") }
-            ?: extractJsonBody(result.html)
-
-        if (requiresClearance(body)) {
-            throw ChallengeRequiredException("AnimeOnline Ninja Cloudflare challenge detected for $url")
+        if (!response.isSuccessful || body.isBlank()) {
+            Log.w(TAG, "Cronet JSON rejected -> code=${response.statusCode} url=$url")
+            return null
         }
-        if (!body.startsWith("{") && !body.startsWith("[")) {
-            throw IllegalStateException("AnimeOnline Ninja returned invalid JSON for $url")
-        }
-        promoteClearanceCookies(result.finalUrl ?: url)
-        return body
-    }
-
-    private fun fetchJsonDirect(url: String, referer: String): String? {
-        val requestBuilder = Request.Builder()
-            .url(url)
-            .header("User-Agent", NetworkClient.USER_AGENT)
-            .header("Accept", "application/json,text/plain,*/*")
-            .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
-            .header("Referer", referer)
-
-        currentClearanceCookie()?.takeIf { it.isNotBlank() }?.let { cookie ->
-            requestBuilder.header("Cookie", cookie)
-        }
-
-        NetworkClient.default.newCall(requestBuilder.build()).execute().use { response ->
-            val body = response.body?.string().orEmpty()
-            if (!response.isSuccessful || body.isBlank()) {
-                Log.w(TAG, "Direct JSON rejected -> code=${response.code} url=$url")
-                return null
-            }
-            if (requiresClearance(body)) {
-                Log.w(TAG, "Direct JSON received a challenge -> url=$url")
-                return null
-            }
-            val trimmed = body.trim()
-            return if (trimmed.startsWith("{") || trimmed.startsWith("[")) trimmed else null
-        }
-    }
-
-    private fun extractJsonBody(html: String): String {
-        val preBody = Regex("""<pre[^>]*>(.*?)</pre>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
-            .find(html)
-            ?.groupValues
-            ?.getOrNull(1)
-
-        return Jsoup.parse(preBody ?: html).text().trim()
-    }
-
-    private fun decodeJavascriptValue(value: String?): String? {
-        val encoded = value?.trim()?.takeIf { it.isNotEmpty() && it != "null" } ?: return null
-        return when (val decoded = runCatching { JSONTokener(encoded).nextValue() }.getOrNull()) {
-            is String -> decoded
-            null -> null
-            else -> decoded.toString()
-        }
+        val trimmed = body.trim()
+        return if (trimmed.startsWith("{") || trimmed.startsWith("[")) trimmed else null
     }
 
     override suspend fun getHome(): List<Category> {
@@ -326,8 +294,7 @@ object AnimeOnlineNinjaProvider : Provider {
 
         val title = document.extractDetailTitle().ifBlank { id }
         val overview = extractOverview(document, title)
-        val poster = document.selectFirst("meta[property='og:image']")?.attr("content")?.trim()
-            ?.let { artworkUrl(it, url) }
+        val poster = extractDetailArtwork(document, url)
         val released = document.selectFirst("meta[property='article:published_time']")?.attr("content")?.take(10)
 
         return Movie(
@@ -345,7 +312,7 @@ object AnimeOnlineNinjaProvider : Provider {
         val document = getDocument(url)
         val title = document.extractDetailTitle().ifBlank { id }
         val overview = extractOverview(document, title)
-        val poster = artworkUrl(document.selectFirst("meta[property='og:image']")?.attr("content")?.trim(), url)
+        val poster = extractDetailArtwork(document, url)
         val banner = poster
         val released = document.selectFirst("meta[property='article:published_time']")?.attr("content")?.take(10)
         val seasons = parseSeasons(document, url, poster)
@@ -698,6 +665,26 @@ object AnimeOnlineNinjaProvider : Provider {
         }
     }
 
+    private fun extractDetailArtwork(document: Document, referer: String): String? {
+        val pagePoster = document
+            .selectFirst(".sheader .poster img, #single .poster img, article.post .poster img")
+            ?.let { image ->
+                image.absUrl("data-src")
+                    .ifBlank { image.attr("data-src") }
+                    .ifBlank { image.absUrl("src") }
+                    .ifBlank { image.attr("src") }
+            }
+            ?.takeIf { it.isNotBlank() && !it.startsWith("data:", ignoreCase = true) }
+
+        val openGraphPoster = document
+            .selectFirst("meta[property='og:image']")
+            ?.attr("content")
+            ?.trim()
+            ?.takeIf(String::isNotBlank)
+
+        return artworkUrl(pagePoster ?: openGraphPoster, referer)
+    }
+
     private fun parseParentTvShow(element: Element, href: String, poster: String?): TvShow? {
         val parentTitle = listOfNotNull(
             element.selectFirst(".season_m .c")?.text()?.trim(),
@@ -923,16 +910,21 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private suspend fun resolveServers(embedUrl: String, source: Int, pageUrl: String): List<Video.Server> {
-        val html = providerMutex.withLock {
-            getResolver().get(
-                embedUrl,
-                mapOf(
-                    "Referer" to pageUrl,
-                    "User-Agent" to NetworkClient.USER_AGENT,
-                ),
-            )
+        val response = AnimeOnlineNinjaCronetClient.get(
+            context = StreamFlixApp.instance,
+            url = embedUrl,
+            headers = mapOf(
+                "Referer" to pageUrl,
+                "User-Agent" to NetworkClient.USER_AGENT,
+                "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language" to "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7",
+            ),
+            useCache = false,
+        )
+        if (!response.isSuccessful) {
+            throw IllegalStateException("Cronet embed HTTP ${response.statusCode}: $embedUrl")
         }
-        val document = Jsoup.parse(html, embedUrl)
+        val document = Jsoup.parse(response.bodyAsString(), response.finalUrl)
         val servers = linkedMapOf<String, Video.Server>()
 
         document.select("li[onclick*='go_to_player']").forEachIndexed { index, element ->
@@ -1031,11 +1023,14 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private fun requiresClearance(html: String): Boolean {
+        // Do not match every /cdn-cgi/challenge-platform/ reference. Cloudflare
+        // injects its lightweight JSD script into ordinary, fully usable pages.
+        // These markers belong to the actual interstitial challenge document.
         return html.contains("cf-browser-verification", ignoreCase = true) ||
                 html.contains("Just a moment...", ignoreCase = true) ||
                 html.contains("Checking your browser", ignoreCase = true) ||
-                html.contains("/cdn-cgi/challenge-platform/", ignoreCase = true) ||
-                html.contains("cf-chl-", ignoreCase = true) ||
+                html.contains("window._cf_chl_opt", ignoreCase = true) ||
+                html.contains("__cf_chl_tk=", ignoreCase = true) ||
                 html.contains("challenge-form", ignoreCase = true)
     }
 
@@ -1072,36 +1067,34 @@ object AnimeOnlineNinjaProvider : Provider {
         return clearanceCookieHeader?.takeIf { it.isNotBlank() }
     }
 
-    fun clearanceCookieForGlide(): String? {
-        return currentClearanceCookie()
-    }
+    fun clearanceCookieForCronet(): String? = currentClearanceCookie()
 
-    private fun fetchDocumentDirect(url: String): Document? {
-        val requestBuilder = Request.Builder()
-            .url(url)
-            .header("User-Agent", NetworkClient.USER_AGENT)
-            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-            .header("Accept-Language", "es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7")
-            .header("Referer", baseUrl)
-
-        currentClearanceCookie()?.takeIf { it.isNotBlank() }?.let { cookie ->
-            requestBuilder.header("Cookie", cookie)
+    private suspend fun fetchDocumentDirect(url: String): Document? {
+        val headers = pageHeaders(baseUrl)
+        val response = AnimeOnlineNinjaCronetClient.get(
+            context = StreamFlixApp.instance,
+            url = url,
+            headers = headers,
+            useCache = false,
+        )
+        val body = response.bodyAsString()
+        if (requiresClearance(body) || response.finalUrl.contains("/cdn-cgi/", ignoreCase = true)) {
+            Log.w(TAG, "Cronet page received a challenge -> url=${response.finalUrl}")
+            throw ChallengeRequiredException(
+                message = "AnimeOnline Ninja Cloudflare challenge detected for $url",
+                rejectedClearance = clearanceToken(headers["Cookie"]),
+            )
+        }
+        if (!response.isSuccessful || body.isBlank()) {
+            Log.w(TAG, "Cronet page rejected -> code=${response.statusCode} url=$url")
+            return null
         }
 
-        NetworkClient.default.newCall(requestBuilder.build()).execute().use { response ->
-            val body = response.body?.string().orEmpty()
-            if (!response.isSuccessful || body.isBlank()) {
-                Log.w(TAG, "Direct page rejected -> code=${response.code} url=$url")
-                return null
-            }
-
-            val finalUrl = response.request.url.toString()
-            if (requiresClearance(body) || !hasUsableSiteContent(body, finalUrl)) {
-                Log.w(TAG, "Direct page was challenged or incomplete -> url=$finalUrl size=${body.length}")
-                return null
-            }
-            return Jsoup.parse(body, finalUrl).apply { setBaseUri(finalUrl) }
+        if (!hasUsableSiteContent(body, response.finalUrl)) {
+            Log.w(TAG, "Cronet page was incomplete -> url=${response.finalUrl} size=${body.length}")
+            return null
         }
+        return Jsoup.parse(body, response.finalUrl).apply { setBaseUri(response.finalUrl) }
     }
 
     private fun cacheDocument(requestUrl: String, document: Document) {
@@ -1122,10 +1115,11 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private fun promoteClearanceCookieHeader(cookieHeader: String?) {
-        val normalized = cookieHeader?.trim()?.takeIf { it.isNotBlank() } ?: return
-        if (normalized != clearanceCookieHeader) {
-            documentCache.clear()
-        }
+        val normalized = cookieHeader?.trim()?.takeIf(String::isNotBlank) ?: return
+
+        if (normalized == clearanceCookieHeader) return
+
+        reload()
         clearanceCookieHeader = normalized
         AnimeOnlineNinjaClearanceStore.update(normalized)
     }

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -1,4 +1,4 @@
-﻿package com.streamflixreborn.streamflix.providers
+package com.streamflixreborn.streamflix.providers
 
 import android.content.Context
 import android.util.Log
@@ -282,7 +282,6 @@ object AnimeOnlineNinjaProvider : Provider {
                 Genre("live-action", "Live action"),
                 Genre("tendencias", "Popular en la web"),
                 Genre("ratings", "Mejores valorados"),
-                Genre("audio-latino", "Audio latino"),
                 Genre("award-winning-anime", "Ganadores de premios"),
                 Genre("accion", "Accion"),
                 Genre("aventura", "Aventura"),
@@ -291,13 +290,14 @@ object AnimeOnlineNinjaProvider : Provider {
                 Genre("terror", "Terror"),
                 Genre("ver-anime", "Ver Anime"),
                 Genre("pelicula", "Peliculas"),
+
             )
         }
 
         if (page > 1) return emptyList()
         val encoded = URLEncoder.encode(query, "UTF-8")
         val document = getDocument("$baseUrl/?s=$encoded")
-        return parseListingItems(document)
+        return parseSearchItems(document)
     }
 
     override suspend fun getMovies(page: Int): List<Movie> {
@@ -482,13 +482,15 @@ object AnimeOnlineNinjaProvider : Provider {
         val url = if (page <= 1) "$baseUrl/$path/" else "$baseUrl/$path/page/$page/"
 
         val document = getDocument(url)
-        val title = document.selectFirst("h1")?.text()?.trim()
+        val title = document.selectFirst(".module .content.right header h1, .module .content.right h1")
+            ?.text()
+            ?.trim()
             ?: slug.replace('-', ' ').replaceFirstChar { it.uppercase() }
 
         return Genre(
             id = id,
             name = title,
-            shows = parseListingItems(document).mapNotNull {
+            shows = parseGenreItems(document).mapNotNull {
                 when (it) {
                     is Movie -> it
                     is TvShow -> it
@@ -720,6 +722,25 @@ object AnimeOnlineNinjaProvider : Provider {
         return selectors
             .flatMap { selector -> root.select(selector) }
             .mapNotNull { parseListingItem(it) }
+            .distinctBy(::itemKey)
+    }
+
+    private fun parseSearchItems(document: Document): List<AppAdapter.Item> {
+        return document
+            .select(".search-page > .result-item > article, .search-page .result-item article")
+            .mapNotNull(::parseListingItem)
+            .distinctBy(::itemKey)
+    }
+
+    private fun parseGenreItems(document: Document): List<AppAdapter.Item> {
+        val grid = document.selectFirst(".module > .content.right > .items")
+            ?: document.selectFirst(".module .content.right .items")
+            ?: return emptyList()
+
+        return grid
+            .children()
+            .filter { child -> child.hasClass("item") || child.tagName() == "article" }
+            .mapNotNull(::parseListingItem)
             .distinctBy(::itemKey)
     }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -833,7 +833,9 @@ object AnimeOnlineNinjaProvider : Provider {
     private fun extractOverview(document: Document, title: String?): String? {
         val synopsis = extractSynopsisText(document, title)
         return synopsis?.takeIf { it.isNotBlank() }
-            ?: document.selectFirst("meta[name='description']")?.attr("content")?.trim()?.takeIf { it.isNotBlank() }
+            ?: document.selectFirst("meta[name='description']")
+                ?.attr("content")
+                ?.cleanOverviewText(title)
     }
 
     private fun extractSynopsisText(document: Document, title: String?): String? {
@@ -850,29 +852,33 @@ object AnimeOnlineNinjaProvider : Provider {
                 ?: heading.parent()?.selectFirst(".wp-content")
         }
 
-        synopsisContainer?.select("p, li")?.forEach { block ->
-            val text = block.text().trim().cleanOverviewText(title)
-            if (text != null) return text
-        }
+        synopsisContainer?.select("p, li")
+            ?.mapNotNull { block -> block.text().trim().cleanOverviewText(title) }
+            ?.distinct()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { return it.joinToString("\n\n") }
 
+        val siblingBlocks = mutableListOf<String>()
         var sibling = heading.nextElementSibling()
         var attempts = 0
         while (sibling != null && attempts < 10) {
             if (sibling.tagName().equals("p", ignoreCase = true) ||
                 sibling.tagName().equals("li", ignoreCase = true)) {
-                val text = sibling.text().trim().cleanOverviewText(title)
-                if (text != null) return text
+                sibling.text().trim().cleanOverviewText(title)?.let(siblingBlocks::add)
             }
             sibling = sibling.nextElementSibling()
             attempts++
         }
 
-        return null
+        return siblingBlocks.distinct().takeIf { it.isNotEmpty() }?.joinToString("\n\n")
     }
 
     private fun String.cleanOverviewText(title: String?): String? {
         val normalized = replace(Regex("""\s+"""), " ").trim()
-        if (normalized.isBlank() || normalized.length < 60) return null
+        // Some pages only provide a concise synopsis (for example,
+        // "Secuela de Chainsaw Man"), so length alone is not a reliable
+        // indication that a synopsis block is junk.
+        if (normalized.length < 10) return null
 
         val lower = normalized.lowercase()
         if (Regex("""^ver\s+.+\s+(online|mega|sub español|audio español)""", RegexOption.IGNORE_CASE).containsMatchIn(normalized)) {

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -248,9 +248,6 @@ object AnimeOnlineNinjaProvider : Provider {
         val body = response.bodyAsString()
         val trimmed = body.trim()
 
-        // A valid JSON response must win over incidental challenge strings in its
-        // payload. Cloudflare detection is only relevant when the expected API
-        // response was not returned.
         if (response.isSuccessful &&
             (trimmed.startsWith("{") || trimmed.startsWith("["))
         ) {
@@ -275,15 +272,10 @@ object AnimeOnlineNinjaProvider : Provider {
         val document = getDocument("$baseUrl/inicio/")
         val categories = parseHomeCategories(document).takeIf { it.isNotEmpty() }
             ?: throw IllegalStateException("AnimeOnline Ninja home page contained no recognizable categories")
-        return resolveHomeEpisodeTvShows(categories)
+        return resolveHomeEpisodeCards(categories)
     }
 
-    /**
-     * The site's latest-episode cards link to an episode and use a landscape
-     * frame from that episode. Resolve those cards before exposing the home
-     * catalog so the app always receives the canonical show id and show cover.
-     */
-    private suspend fun resolveHomeEpisodeTvShows(categories: List<Category>): List<Category> = coroutineScope {
+    private suspend fun resolveHomeEpisodeCards(categories: List<Category>): List<Category> = coroutineScope {
         val episodeCards = categories
             .flatMap { it.list }
             .filterIsInstance<TvShow>()
@@ -296,15 +288,25 @@ object AnimeOnlineNinjaProvider : Provider {
             .distinctBy { titleKey(it.title) }
             .map { episodeCard ->
                 async {
-                    val resolved = runCatching {
+                    val tvShowResult = runCatching {
                         requestLimit.withPermit { getTvShow(episodeCard.id) }
-                    }.onFailure { error ->
+                    }
+                    val movieResult = if (tvShowResult.isFailure) {
+                        runCatching {
+                            requestLimit.withPermit { resolveHomeEpisodeMovie(episodeCard) }
+                        }
+                    } else {
+                        Result.success(null)
+                    }
+                    val resolved: Show? = tvShowResult.getOrNull() ?: movieResult.getOrNull()
+
+                    if (resolved == null) {
                         Log.w(
                             TAG,
-                            "Unable to resolve home episode ${episodeCard.id} to its TV show",
-                            error,
+                            "Unable to resolve home episode ${episodeCard.id} to a movie or TV show",
+                            tvShowResult.exceptionOrNull() ?: movieResult.exceptionOrNull(),
                         )
-                    }.getOrNull()
+                    }
                     titleKey(episodeCard.title) to resolved
                 }
             }
@@ -326,6 +328,15 @@ object AnimeOnlineNinjaProvider : Provider {
         }
     }
 
+    private suspend fun resolveHomeEpisodeMovie(episodeCard: TvShow): Movie? {
+        val query = URLEncoder.encode(episodeCard.title, "UTF-8")
+        val searchDocument = getDocument("$baseUrl/?s=$query")
+        val movieUrl = findMatchingShowUrl(searchDocument, episodeCard.title, "/pelicula/")
+            ?: return null
+
+        return getMovie(normalizeId(movieUrl, "/pelicula/"))
+    }
+
     override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
         if (query.isBlank()) {
             return listOf(
@@ -336,7 +347,6 @@ object AnimeOnlineNinjaProvider : Provider {
                 Genre("live-action", "Live action"),
                 Genre("tendencias", "Popular en la web"),
                 Genre("ratings", "Mejores valorados"),
-                Genre("sin-censura", "Sin censura"),
                 Genre("award-winning-anime", "Ganadores de premios"),
                 Genre("accion", "Accion"),
                 Genre("aventura", "Aventura"),
@@ -455,10 +465,18 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private fun findMatchingTvShowUrl(document: Document, parentTitle: String): String? {
+        return findMatchingShowUrl(document, parentTitle, "/online/")
+    }
+
+    private fun findMatchingShowUrl(
+        document: Document,
+        parentTitle: String,
+        path: String,
+    ): String? {
         val targetKey = titleKey(parentTitle)
         if (targetKey.isBlank()) return null
 
-        return document.select("a[href*='/online/']")
+        return document.select("a[href*='$path']")
             .mapNotNull { link ->
                 val href = link.absUrl("href").ifBlank { link.attr("href") }
                 if (href.isBlank()) return@mapNotNull null
@@ -469,7 +487,7 @@ object AnimeOnlineNinjaProvider : Provider {
                     link.selectFirst("img[alt]")?.attr("alt").orEmpty(),
                     link.parent()?.text().orEmpty(),
                     runCatching {
-                        URLDecoder.decode(normalizeId(href, "/online/"), "UTF-8")
+                        URLDecoder.decode(normalizeId(href, path), "UTF-8")
                             .replace('-', ' ')
                     }.getOrDefault(""),
                 )
@@ -545,7 +563,7 @@ object AnimeOnlineNinjaProvider : Provider {
         return Genre(
             id = id,
             name = title,
-            shows = parseGenreItems(document).mapNotNull {
+            shows = parseArchiveItems(document).mapNotNull {
                 when (it) {
                     is Movie -> it
                     is TvShow -> it
@@ -709,7 +727,7 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private suspend fun getListing(url: String): List<AppAdapter.Item> {
-        return getDocument(url).let(::parseListingItems)
+        return getDocument(url).let(::parseArchiveItems)
     }
 
     private fun listingUrl(path: String, page: Int): String {
@@ -781,21 +799,16 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private fun parseSearchItems(document: Document): List<AppAdapter.Item> {
-        // Search pages also render unrelated recommendations in the right sidebar.
-        // Only result cards inside the dedicated search result container belong to
-        // the submitted query.
         return document
             .select(".search-page > .result-item > article, .search-page .result-item article")
             .mapNotNull(::parseListingItem)
             .distinctBy(::itemKey)
     }
 
-    private fun parseGenreItems(document: Document): List<AppAdapter.Item> {
-        // Genre archives paginate their main grid at /page/{n}/. Scoping the
-        // parser to that grid makes every requested page independent from the
-        // sidebar modules that are repeated on all archive pages.
-        val grid = document.selectFirst(".module > .content.right > .items")
-            ?: document.selectFirst(".module .content.right .items")
+    private fun parseArchiveItems(document: Document): List<AppAdapter.Item> {
+        val grid = document.selectFirst("#archive-content")
+            ?: document.selectFirst(".module > .content.right > .items:not(.featured)")
+            ?: document.selectFirst(".module .content.right .items:not(.featured)")
             ?: return emptyList()
 
         return grid

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AnimeOnlineNinjaProvider.kt
@@ -57,6 +57,7 @@ object AnimeOnlineNinjaProvider : Provider {
     fun init(context: Context) {
         webViewResolver = WebViewResolver(context)
         AnimeOnlineNinjaCronetClient.init(context)
+        syncClearanceCookieState()
     }
 
     fun reload() {
@@ -75,6 +76,9 @@ object AnimeOnlineNinjaProvider : Provider {
     ) : IllegalStateException(message)
 
     private suspend fun getDocument(url: String): Document {
+        // Do this even when the document is cached. CookieManager is the source of
+        // truth for expiry; an old in-memory cf_clearance must never reach Cronet.
+        syncClearanceCookieState()
         cachedDocument(url)?.let { cached ->
             return cached.document.clone().apply { setBaseUri(cached.finalUrl) }
         }
@@ -131,12 +135,17 @@ object AnimeOnlineNinjaProvider : Provider {
             getResolver().getResult(
                 url = url,
                 headers = pageHeaders(referer).minus("Cookie"),
-                completion = { currentUrl, _, cookies ->
+                completion = { currentUrl, html, cookies ->
                     val newClearance = clearanceToken(cookies)
-                    val hasClearance = !newClearance.isNullOrBlank() && newClearance != currentClearance
+                    val hasClearance = !newClearance.isNullOrBlank()
+                    val hasUsableContent = hasUsableSiteContent(html, currentUrl)
                     if (hasClearance) promoteClearanceCookieHeader(cookies)
-                    Log.d(TAG, "WebView challenge poll -> url=$currentUrl clearance=$hasClearance")
-                    hasClearance
+                    Log.d(
+                        TAG,
+                        "WebView challenge poll -> url=$currentUrl clearance=$hasClearance " +
+                                "changed=${newClearance != currentClearance} content=$hasUsableContent"
+                    )
+                    hasClearance || hasUsableContent
                 },
                 shouldAllowNavigation = { targetUrl, _ ->
                     runCatching {
@@ -178,7 +187,6 @@ object AnimeOnlineNinjaProvider : Provider {
             ?.filterNot { it.startsWith("cf_clearance=", ignoreCase = true) }
             ?.joinToString("; ")
             ?.takeIf(String::isNotBlank)
-        AnimeOnlineNinjaClearanceStore.update(clearanceCookieHeader)
     }
 
     private fun artworkUrl(url: String?, referer: String = baseUrl): String? {
@@ -213,6 +221,7 @@ object AnimeOnlineNinjaProvider : Provider {
     }
 
     private suspend fun getJsonBody(url: String, referer: String): String {
+        syncClearanceCookieState()
         val body = try {
             fetchJsonDirect(url, referer)
         } catch (challenge: ChallengeRequiredException) {
@@ -232,6 +241,17 @@ object AnimeOnlineNinjaProvider : Provider {
             useCache = false,
         )
         val body = response.bodyAsString()
+        val trimmed = body.trim()
+
+        // A valid JSON response must win over incidental challenge strings in its
+        // payload. Cloudflare detection is only relevant when the expected API
+        // response was not returned.
+        if (response.isSuccessful &&
+            (trimmed.startsWith("{") || trimmed.startsWith("["))
+        ) {
+            return trimmed
+        }
+
         if (requiresClearance(body) || response.finalUrl.contains("/cdn-cgi/", ignoreCase = true)) {
             Log.w(TAG, "Cronet JSON received a challenge -> url=$url")
             throw ChallengeRequiredException(
@@ -243,8 +263,7 @@ object AnimeOnlineNinjaProvider : Provider {
             Log.w(TAG, "Cronet JSON rejected -> code=${response.statusCode} url=$url")
             return null
         }
-        val trimmed = body.trim()
-        return if (trimmed.startsWith("{") || trimmed.startsWith("[")) trimmed else null
+        return null
     }
 
     override suspend fun getHome(): List<Category> {
@@ -1084,13 +1103,13 @@ object AnimeOnlineNinjaProvider : Provider {
 
     private fun requiresClearance(html: String): Boolean {
         // Do not match every /cdn-cgi/challenge-platform/ reference. Cloudflare
-        // injects its lightweight JSD script into ordinary, fully usable pages.
-        // These markers belong to the actual interstitial challenge document.
+        // injects its lightweight JSD script and __cf_chl_tk links into ordinary,
+        // fully usable pages. Only markers belonging to the interstitial itself
+        // are considered a challenge here.
         return html.contains("cf-browser-verification", ignoreCase = true) ||
                 html.contains("Just a moment...", ignoreCase = true) ||
                 html.contains("Checking your browser", ignoreCase = true) ||
                 html.contains("window._cf_chl_opt", ignoreCase = true) ||
-                html.contains("__cf_chl_tk=", ignoreCase = true) ||
                 html.contains("challenge-form", ignoreCase = true)
     }
 
@@ -1103,7 +1122,7 @@ object AnimeOnlineNinjaProvider : Provider {
         }
 
     }
-    private fun currentClearanceCookie(): String? {
+    private fun syncClearanceCookieState(): String? {
         val cookieManager = CookieManager.getInstance()
         val candidates = listOf(
             "$SITE_BASE_URL/",
@@ -1112,19 +1131,27 @@ object AnimeOnlineNinjaProvider : Provider {
             baseUrl
         )
 
-        candidates.firstNotNullOfOrNull { candidate ->
-            cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
-        }?.also {
-            clearanceCookieHeader = it
-            AnimeOnlineNinjaClearanceStore.update(it)
-        }?.let { return it }
+        val liveCookieHeaders = candidates.mapNotNull { candidate ->
+            cookieManager.getCookie(candidate)?.trim()?.takeIf(String::isNotBlank)
+        }.distinct()
+        val liveCookieHeader = liveCookieHeaders.firstOrNull { header ->
+            !clearanceToken(header).isNullOrBlank()
+        } ?: liveCookieHeaders.firstOrNull()
 
-        AnimeOnlineNinjaClearanceStore.cookieHeader()?.takeIf { it.isNotBlank() }?.let {
-            clearanceCookieHeader = it
-            return it
+        val staleClearance = clearanceToken(clearanceCookieHeader)
+        if (!staleClearance.isNullOrBlank() && clearanceToken(liveCookieHeader).isNullOrBlank()) {
+            Log.d(TAG, "Discarding expired Cloudflare clearance before request")
+            reload()
         }
 
-        return clearanceCookieHeader?.takeIf { it.isNotBlank() }
+        clearanceCookieHeader = liveCookieHeader
+        return liveCookieHeader
+    }
+
+    private fun currentClearanceCookie(): String? = syncClearanceCookieState()
+
+    fun hasCurrentClearanceCookie(): Boolean {
+        return !clearanceToken(syncClearanceCookieState()).isNullOrBlank()
     }
 
     fun clearanceCookieForCronet(): String? = currentClearanceCookie()
@@ -1138,6 +1165,17 @@ object AnimeOnlineNinjaProvider : Provider {
             useCache = false,
         )
         val body = response.bodyAsString()
+
+        // Cloudflare may append challenge-related scripts or tokenized links to a
+        // normal WordPress page. Accept a successful, recognizable provider page
+        // before inspecting those incidental markers.
+        if (response.isSuccessful &&
+            body.isNotBlank() &&
+            hasUsableSiteContent(body, response.finalUrl)
+        ) {
+            return Jsoup.parse(body, response.finalUrl).apply { setBaseUri(response.finalUrl) }
+        }
+
         if (requiresClearance(body) || response.finalUrl.contains("/cdn-cgi/", ignoreCase = true)) {
             Log.w(TAG, "Cronet page received a challenge -> url=${response.finalUrl}")
             throw ChallengeRequiredException(
@@ -1150,11 +1188,8 @@ object AnimeOnlineNinjaProvider : Provider {
             return null
         }
 
-        if (!hasUsableSiteContent(body, response.finalUrl)) {
-            Log.w(TAG, "Cronet page was incomplete -> url=${response.finalUrl} size=${body.length}")
-            return null
-        }
-        return Jsoup.parse(body, response.finalUrl).apply { setBaseUri(response.finalUrl) }
+        Log.w(TAG, "Cronet page was incomplete -> url=${response.finalUrl} size=${body.length}")
+        return null
     }
 
     private fun cacheDocument(requestUrl: String, document: Document) {
@@ -1181,7 +1216,6 @@ object AnimeOnlineNinjaProvider : Provider {
 
         reload()
         clearanceCookieHeader = normalized
-        AnimeOnlineNinjaClearanceStore.update(normalized)
     }
 
     private fun logFailure(operation: String, url: String, error: Throwable) {
@@ -1194,15 +1228,4 @@ object AnimeOnlineNinjaProvider : Provider {
         val expiresAt: Long,
     )
 
-}
-
-private object AnimeOnlineNinjaClearanceStore {
-    @Volatile
-    private var cookieHeader: String? = null
-
-    fun update(cookieHeader: String?) {
-        this.cookieHeader = cookieHeader?.trim()?.takeIf { it.isNotBlank() }
-    }
-
-    fun cookieHeader(): String? = cookieHeader
 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/ui/AnimeOnlineNinjaCronetUrlLoader.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/ui/AnimeOnlineNinjaCronetUrlLoader.kt
@@ -1,0 +1,116 @@
+package com.streamflixreborn.streamflix.ui
+
+import android.content.Context
+import com.bumptech.glide.Priority
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.data.DataFetcher
+import com.bumptech.glide.load.model.GlideUrl
+import com.bumptech.glide.load.model.ModelLoader
+import com.bumptech.glide.load.model.ModelLoaderFactory
+import com.bumptech.glide.load.model.MultiModelLoaderFactory
+import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
+import com.bumptech.glide.signature.ObjectKey
+import com.streamflixreborn.streamflix.utils.AnimeOnlineNinjaCronetClient
+import com.streamflixreborn.streamflix.providers.AnimeOnlineNinjaProvider
+import com.streamflixreborn.streamflix.utils.ArtworkRequestHeaders
+import com.streamflixreborn.streamflix.utils.NetworkClient
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.URI
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+
+class AnimeOnlineNinjaCronetUrlLoader(
+    private val context: Context,
+    private val fallback: ModelLoader<GlideUrl, InputStream>,
+) :
+    ModelLoader<GlideUrl, InputStream> {
+
+    private fun isAnimeOnlineNinja(model: GlideUrl): Boolean {
+        return runCatching {
+            URI(model.toStringUrl()).host.equals(AnimeOnlineNinjaProvider.cronetHost, ignoreCase = true)
+        }.getOrDefault(false)
+    }
+
+    override fun handles(model: GlideUrl): Boolean = true
+
+    override fun buildLoadData(
+        model: GlideUrl,
+        width: Int,
+        height: Int,
+        options: Options,
+    ): ModelLoader.LoadData<InputStream> {
+        return if (isAnimeOnlineNinja(model)) {
+            ModelLoader.LoadData(ObjectKey(model), Fetcher(context, model))
+        } else {
+            requireNotNull(fallback.buildLoadData(model, width, height, options))
+        }
+    }
+
+    class Factory(
+        private val context: Context,
+        private val okHttpClient: OkHttpClient,
+    ) : ModelLoaderFactory<GlideUrl, InputStream> {
+        override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<GlideUrl, InputStream> {
+            val fallback = OkHttpUrlLoader.Factory(okHttpClient).build(multiFactory)
+            return AnimeOnlineNinjaCronetUrlLoader(context.applicationContext, fallback)
+        }
+
+        override fun teardown() = Unit
+    }
+
+    private class Fetcher(
+        private val context: Context,
+        private val model: GlideUrl,
+    ) : DataFetcher<InputStream> {
+        private var call: AnimeOnlineNinjaCronetClient.Call? = null
+        private var stream: InputStream? = null
+
+        override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in InputStream>) {
+            val sourceUrl = model.toStringUrl()
+            val parsed = sourceUrl.toHttpUrl()
+            val requestUrl = ArtworkRequestHeaders.stripHeaders(parsed).toString()
+            val headers = buildMap {
+                putAll(model.headers)
+                putAll(ArtworkRequestHeaders.headersFor(parsed))
+                putIfAbsent("User-Agent", NetworkClient.USER_AGENT)
+                putIfAbsent("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+                AnimeOnlineNinjaProvider.clearanceCookieForCronet()
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { put("Cookie", it) }
+            }
+
+            call = AnimeOnlineNinjaCronetClient.get(context, requestUrl, headers) { result ->
+                result.fold(
+                    onSuccess = { response ->
+                        if (!response.isSuccessful) {
+                            callback.onLoadFailed(IllegalStateException("Cronet image HTTP ${response.statusCode}: $requestUrl"))
+                        } else {
+                            ByteArrayInputStream(response.body).also {
+                                stream = it
+                                callback.onDataReady(it)
+                            }
+                        }
+                    },
+                    onFailure = { error ->
+                        callback.onLoadFailed(error as? Exception ?: RuntimeException(error))
+                    },
+                )
+            }
+        }
+
+        override fun cleanup() {
+            stream?.close()
+            stream = null
+        }
+
+        override fun cancel() {
+            call?.cancel()
+        }
+
+        override fun getDataClass(): Class<InputStream> = InputStream::class.java
+
+        override fun getDataSource(): DataSource = DataSource.REMOTE
+    }
+}

--- a/app/src/main/java/com/streamflixreborn/streamflix/ui/GlideCustomModule.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/ui/GlideCustomModule.kt
@@ -1,23 +1,19 @@
 package com.streamflixreborn.streamflix.ui
 
 import android.content.Context
-import android.webkit.CookieManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.annotation.GlideModule
-import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.module.AppGlideModule
 import com.streamflixreborn.streamflix.utils.ArtworkRequestHeaders
 import com.streamflixreborn.streamflix.utils.DnsResolver
 import com.streamflixreborn.streamflix.utils.NetworkClient
-import com.streamflixreborn.streamflix.providers.AnimeOnlineNinjaProvider
 import okhttp3.*
 import okhttp3.OkHttpClient.Builder
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.File
 import java.io.InputStream
 import java.security.SecureRandom
-import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
@@ -77,7 +73,7 @@ class GlideCustomModule : AppGlideModule() {
                 } else {
                     request
                 }
-                chain.proceed(fixedRequest.withAnimeOnlineCookies())
+                chain.proceed(fixedRequest)
             }
             .addInterceptor(logging)
             .sslSocketFactory(sslContext.socketFactory, trustManager)
@@ -91,7 +87,9 @@ class GlideCustomModule : AppGlideModule() {
     ) {
         val okHttpClient = getOkHttpClient(context)
         registry.replace(
-            GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(okHttpClient)
+            GlideUrl::class.java,
+            InputStream::class.java,
+            AnimeOnlineNinjaCronetUrlLoader.Factory(context, okHttpClient),
         )
     }
 
@@ -105,32 +103,4 @@ class GlideCustomModule : AppGlideModule() {
         }
     }
 
-    private fun Request.withAnimeOnlineCookies(): Request {
-        val host = url.host.lowercase(Locale.ROOT)
-        if (host != "ww3.animeonline.ninja" || header("Cookie") != null) return this
-
-        val cookie = animeOnlineCookieHeader(url) ?: return this
-        return newBuilder()
-            .header("Cookie", cookie)
-            .build()
-    }
-
-    private fun animeOnlineCookieHeader(url: HttpUrl): String? {
-        AnimeOnlineNinjaProvider.run {
-            clearanceCookieForGlide()?.takeIf { it.isNotBlank() }?.let { return it }
-        }
-
-        val cookieManager = CookieManager.getInstance()
-        val exact = url.newBuilder().fragment(null).build().toString()
-        val root = url.newBuilder().encodedPath("/").query(null).fragment(null).build().toString()
-
-        return listOf(
-            exact,
-            root,
-            "https://ww3.animeonline.ninja/",
-            "https://ww3.animeonline.ninja"
-        ).firstNotNullOfOrNull { candidate ->
-            cookieManager.getCookie(candidate)?.takeIf { it.isNotBlank() }
-        }
-    }
 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/AnimeOnlineNinjaCronetClient.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/AnimeOnlineNinjaCronetClient.kt
@@ -1,0 +1,184 @@
+package com.streamflixreborn.streamflix.utils
+
+import android.content.Context
+import android.webkit.CookieManager
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.chromium.net.CronetEngine
+import org.chromium.net.CronetException
+import org.chromium.net.UrlRequest
+import org.chromium.net.UrlResponseInfo
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+object AnimeOnlineNinjaCronetClient {
+    private const val CACHE_SIZE_BYTES = 20L * 1024L * 1024L
+    private const val READ_BUFFER_SIZE = 32 * 1024
+
+    data class Response(
+        val statusCode: Int,
+        val finalUrl: String,
+        val headers: Map<String, List<String>>,
+        val body: ByteArray,
+    ) {
+        val isSuccessful: Boolean get() = statusCode in 200..299
+
+        fun bodyAsString(): String = body.toString(Charsets.UTF_8)
+    }
+
+    fun interface Callback {
+        fun onComplete(result: Result<Response>)
+    }
+
+    class Call internal constructor() {
+        @Volatile
+        private var request: UrlRequest? = null
+        private val cancelled = AtomicBoolean(false)
+
+        internal fun attach(request: UrlRequest) {
+            this.request = request
+            if (cancelled.get()) request.cancel()
+        }
+
+        fun cancel() {
+            cancelled.set(true)
+            request?.cancel()
+        }
+
+        internal fun isCancelled(): Boolean = cancelled.get()
+    }
+
+    @Volatile
+    private var engine: CronetEngine? = null
+    private val executor: ExecutorService = Executors.newCachedThreadPool { runnable ->
+        Thread(runnable, "anime-ninja-cronet").apply { isDaemon = true }
+    }
+
+    fun init(context: Context) {
+        engine(context)
+    }
+
+    suspend fun get(
+        context: Context,
+        url: String,
+        headers: Map<String, String>,
+        useCache: Boolean = true,
+    ): Response = suspendCancellableCoroutine { continuation ->
+        val call = get(context, url, headers, useCache) { result ->
+            if (!continuation.isActive) return@get
+            result.fold(continuation::resume, continuation::resumeWithException)
+        }
+        continuation.invokeOnCancellation { call.cancel() }
+    }
+
+    fun get(
+        context: Context,
+        url: String,
+        headers: Map<String, String>,
+        useCache: Boolean = true,
+        callback: Callback,
+    ): Call {
+        val call = Call()
+        val completed = AtomicBoolean(false)
+        val output = ByteArrayOutputStream()
+
+        fun complete(result: Result<Response>) {
+            if (!call.isCancelled() && completed.compareAndSet(false, true)) {
+                callback.onComplete(result)
+            }
+        }
+
+        val requestCallback = object : UrlRequest.Callback() {
+            override fun onRedirectReceived(
+                request: UrlRequest,
+                info: UrlResponseInfo,
+                newLocationUrl: String,
+            ) {
+                persistCookies(info)
+                request.followRedirect()
+            }
+
+            override fun onResponseStarted(request: UrlRequest, info: UrlResponseInfo) {
+                persistCookies(info)
+                request.read(ByteBuffer.allocateDirect(READ_BUFFER_SIZE))
+            }
+
+            override fun onReadCompleted(
+                request: UrlRequest,
+                info: UrlResponseInfo,
+                byteBuffer: ByteBuffer,
+            ) {
+                byteBuffer.flip()
+                val bytes = ByteArray(byteBuffer.remaining())
+                byteBuffer.get(bytes)
+                output.write(bytes)
+                byteBuffer.clear()
+                request.read(byteBuffer)
+            }
+
+            override fun onSucceeded(request: UrlRequest, info: UrlResponseInfo) {
+                persistCookies(info)
+                complete(
+                    Result.success(
+                        Response(
+                            statusCode = info.httpStatusCode,
+                            finalUrl = info.url,
+                            headers = info.allHeaders,
+                            body = output.toByteArray(),
+                        )
+                    )
+                )
+            }
+
+            override fun onFailed(
+                request: UrlRequest,
+                info: UrlResponseInfo?,
+                error: CronetException,
+            ) {
+                complete(Result.failure(error))
+            }
+
+            override fun onCanceled(request: UrlRequest, info: UrlResponseInfo?) = Unit
+        }
+
+        val builder = engine(context).newUrlRequestBuilder(url, requestCallback, executor)
+            .setHttpMethod("GET")
+        if (!useCache) builder.disableCache()
+        headers.forEach { (name, value) ->
+            if (value.isNotBlank()) builder.addHeader(name, value)
+        }
+        val request = builder.build()
+        call.attach(request)
+        request.start()
+        return call
+    }
+
+    @Synchronized
+    private fun engine(context: Context): CronetEngine {
+        engine?.let { return it }
+        return CronetEngine.Builder(context.applicationContext)
+            .enableHttp2(true)
+            .enableQuic(true)
+            .enableBrotli(true)
+            .setStoragePath(context.cacheDir.resolve("anime-ninja-cronet").apply { mkdirs() }.absolutePath)
+            .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK, CACHE_SIZE_BYTES)
+            .build()
+            .also { engine = it }
+    }
+
+    private fun persistCookies(info: UrlResponseInfo) {
+        val setCookies = info.allHeaders.entries
+            .filter { (name, _) -> name.equals("Set-Cookie", ignoreCase = true) }
+            .flatMap { it.value }
+        if (setCookies.isEmpty()) return
+
+        CookieManager.getInstance().apply {
+            setCookies.forEach { cookie -> setCookie(info.url, cookie) }
+            flush()
+        }
+    }
+}

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/WebViewResolver.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/WebViewResolver.kt
@@ -29,9 +29,15 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONTokener
 import kotlin.coroutines.resume
 
 class WebViewResolver(private val context: Context) {
+
+    private companion object {
+        private const val INITIAL_SCALE = 85
+        private const val PAGE_ZOOM = "0.85"
+    }
 
     data class Result(
         val html: String,
@@ -43,7 +49,7 @@ class WebViewResolver(private val context: Context) {
     private var dialog: AlertDialog? = null
     private val mutex = Mutex()
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val TAG = "Cine24hBypass"
+    private val TAG = "WebviewResolver"
 
     private var cursorX = 0f
     private var cursorY = 0f
@@ -52,6 +58,7 @@ class WebViewResolver(private val context: Context) {
     private var loginKeyboardPrimed = false
     private var deferredLoadUrl: String? = null
     private var deferredLoadHeaders: Map<String, String> = emptyMap()
+    private var lastMobileZoomUrl: String? = null
     private val isTv = context.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     private val activityContext: Activity?
         get() = context.findActivity() ?: StreamFlixApp.currentActivity
@@ -68,7 +75,15 @@ class WebViewResolver(private val context: Context) {
         pageReadyScriptProvider: ((currentUrl: String, html: String, cookies: String) -> String?)? = null,
         showImmediately: Boolean = false,
     ): String {
-        return getResult(url, headers, completion, shouldAllowNavigation, null, pageReadyScriptProvider, showImmediately).html
+        return getResult(
+            url,
+            headers,
+            completion,
+            shouldAllowNavigation,
+            null,
+            pageReadyScriptProvider,
+            showImmediately
+        ).html
     }
 
     suspend fun getResult(
@@ -86,7 +101,16 @@ class WebViewResolver(private val context: Context) {
         val result = withTimeoutOrNull(120000) {
             suspendCancellableCoroutine { continuation ->
                 mainHandler.post {
-                    setupWebView(url, headers, completion, shouldAllowNavigation, valueScript, pageReadyScriptProvider, showImmediately, continuation)
+                    setupWebView(
+                        url,
+                        headers,
+                        completion,
+                        shouldAllowNavigation,
+                        valueScript,
+                        pageReadyScriptProvider,
+                        showImmediately,
+                        continuation
+                    )
                 }
                 continuation.invokeOnCancellation { cleanup() }
             }
@@ -129,9 +153,13 @@ class WebViewResolver(private val context: Context) {
                 mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
                 loadWithOverviewMode = true
                 useWideViewPort = true
+                setSupportZoom(true)
+                builtInZoomControls = true
+                displayZoomControls = false
                 javaScriptCanOpenWindowsAutomatically = false
                 setSupportMultipleWindows(false)
             }
+            setInitialScale(INITIAL_SCALE)
 
             CookieManager.getInstance().setAcceptCookie(true)
             CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
@@ -174,9 +202,17 @@ class WebViewResolver(private val context: Context) {
 
                 override fun onPageFinished(view: WebView?, currentUrl: String?) {
                     Log.d(TAG, "[WebView] onPageFinished: $currentUrl")
+                    applyMobilePageZoomOnce(view, currentUrl)
                     mainHandler.postDelayed({
                         if (webView != null) {
-                            checkChallengeStatus(view, currentUrl ?: url, completion, continuation, valueScript, pageReadyScriptProvider)
+                            checkChallengeStatus(
+                                view,
+                                currentUrl ?: url,
+                                completion,
+                                continuation,
+                                valueScript,
+                                pageReadyScriptProvider
+                            )
                         }
                     }, 1500)
                 }
@@ -191,6 +227,24 @@ class WebViewResolver(private val context: Context) {
         } else {
             webView?.loadUrl(url, headers)
         }
+    }
+
+    private fun applyMobilePageZoomOnce(view: WebView?, currentUrl: String?) {
+        if (view == null || currentUrl.isNullOrBlank() || lastMobileZoomUrl == currentUrl) return
+        lastMobileZoomUrl = currentUrl
+        view.evaluateJavascript(
+            """
+                (function() {
+                    const zoom = '$PAGE_ZOOM';
+                    document.documentElement.style.zoom = zoom;
+                    if (document.body) {
+                        document.body.style.zoom = zoom;
+                    }
+                    return zoom;
+                })();
+            """.trimIndent(),
+            null
+        )
     }
 
     private fun checkChallengeStatus(
@@ -208,8 +262,7 @@ class WebViewResolver(private val context: Context) {
         val hasClearance = cookies.contains("cf_clearance")
 
         view?.evaluateJavascript("(function() { return document.documentElement.innerHTML; })();") { html ->
-            val cleanHtml = html?.trim()?.removeSurrounding("\"")
-                ?.replace("\\u003C", "<")?.replace("\\\"", "\"")?.replace("\\n", "\n") ?: ""
+            val cleanHtml = decodeJavascriptValue(html).orEmpty()
 
             val isChallenge = challengeKeywords.any { cleanHtml.contains(it, ignoreCase = true) }
             val hasContent = cleanHtml.contains("article") || cleanHtml.contains("iframe") ||
@@ -228,7 +281,10 @@ class WebViewResolver(private val context: Context) {
                 view?.evaluateJavascript(pageReadyScript, null)
             }
 
-            Log.d(TAG, "[WebView] Status -> Challenge: $isChallenge, Content: $hasContent, Clearance: $hasClearance, Polling: $pollingCount")
+            Log.d(
+                TAG,
+                "[WebView] Status -> Challenge: $isChallenge, Content: $hasContent, Clearance: $hasClearance, Polling: $pollingCount"
+            )
 
             // Se rileviamo sblocco, chiudiamo tutto subito
             if (success) {
@@ -249,7 +305,14 @@ class WebViewResolver(private val context: Context) {
             pollingCount++
             if (pollingCount < 80) {
                 mainHandler.postDelayed({
-                    checkChallengeStatus(view, currentUrl, completion, continuation, valueScript, pageReadyScriptProvider)
+                    checkChallengeStatus(
+                        view,
+                        currentUrl,
+                        completion,
+                        continuation,
+                        valueScript,
+                        pageReadyScriptProvider
+                    )
                 }, 2000)
             } else {
                 Log.w(TAG, "[WebView] Max polling reached")
@@ -290,6 +353,15 @@ class WebViewResolver(private val context: Context) {
         }
     }
 
+    private fun decodeJavascriptValue(value: String?): String? {
+        val encoded = value?.trim()?.takeIf { it.isNotEmpty() && it != "null" } ?: return null
+        return when (val decoded = runCatching { JSONTokener(encoded).nextValue() }.getOrNull()) {
+            is String -> decoded
+            null -> encoded.removeSurrounding("\"")
+            else -> decoded.toString()
+        }
+    }
+
     private fun showVisibleChallenge(continuation: kotlinx.coroutines.CancellableContinuation<Result>) {
         if (dialog != null || webView == null) return
         mainHandler.post {
@@ -300,12 +372,24 @@ class WebViewResolver(private val context: Context) {
                     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
                         if (event.action == KeyEvent.ACTION_DOWN) {
                             if (isTv) {
-                                val step = 45f
+                                val step = 30f
                                 when (event.keyCode) {
-                                    KeyEvent.KEYCODE_DPAD_UP -> { cursorY -= step; updateCursorPosition(); return true }
-                                    KeyEvent.KEYCODE_DPAD_DOWN -> { cursorY += step; updateCursorPosition(); return true }
-                                    KeyEvent.KEYCODE_DPAD_LEFT -> { cursorX -= step; updateCursorPosition(); return true }
-                                    KeyEvent.KEYCODE_DPAD_RIGHT -> { cursorX += step; updateCursorPosition(); return true }
+                                    KeyEvent.KEYCODE_DPAD_UP -> {
+                                        cursorY -= step; updateCursorPosition(); return true
+                                    }
+
+                                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                                        cursorY += step; updateCursorPosition(); return true
+                                    }
+
+                                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                        cursorX -= step; updateCursorPosition(); return true
+                                    }
+
+                                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                        cursorX += step; updateCursorPosition(); return true
+                                    }
+
                                     KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER -> {
                                         Log.d(TAG, "[WebView] TV OK Key -> Simulating Mouse")
                                         simulateHumanMouseClick()
@@ -396,18 +480,6 @@ class WebViewResolver(private val context: Context) {
                 }
                 Log.d(TAG, "[WebView] Challenge Dialog DISPLAYED (isTv: $isTv)")
 
-                if (isTv) {
-                    val pendingUrl = deferredLoadUrl
-                    if (!pendingUrl.isNullOrBlank()) {
-                        val pendingHeaders = deferredLoadHeaders
-                        deferredLoadUrl = null
-                        deferredLoadHeaders = emptyMap()
-                        webView?.post {
-                            webView?.loadUrl(pendingUrl, pendingHeaders)
-                        }
-                    }
-                }
-
                 if (!isTv) {
                     dialog?.window?.setSoftInputMode(
                         WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE or
@@ -417,6 +489,16 @@ class WebViewResolver(private val context: Context) {
                     webView?.post {
                         webView?.requestFocusFromTouch()
                         showSoftKeyboard(webView)
+                    }
+                }
+
+                val pendingUrl = deferredLoadUrl
+                if (!pendingUrl.isNullOrBlank()) {
+                    val pendingHeaders = deferredLoadHeaders
+                    deferredLoadUrl = null
+                    deferredLoadHeaders = emptyMap()
+                    webView?.post {
+                        webView?.loadUrl(pendingUrl, pendingHeaders)
                     }
                 }
             } catch (e: Exception) {
@@ -473,15 +555,60 @@ class WebViewResolver(private val context: Context) {
             val propM = MotionEvent.PointerProperties().apply { id = 0; toolType = MotionEvent.TOOL_TYPE_MOUSE }
             val coordM = MotionEvent.PointerCoords().apply { x = relX; y = relY; pressure = 1f; size = 1f }
 
-            val hover = MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_HOVER_MOVE, 1, arrayOf(propM), arrayOf(coordM), 0, 0, 1f, 1f, 0, 0, InputDevice.SOURCE_MOUSE, 0)
+            val hover = MotionEvent.obtain(
+                downTime,
+                downTime,
+                MotionEvent.ACTION_HOVER_MOVE,
+                1,
+                arrayOf(propM),
+                arrayOf(coordM),
+                0,
+                0,
+                1f,
+                1f,
+                0,
+                0,
+                InputDevice.SOURCE_MOUSE,
+                0
+            )
             wv.dispatchGenericMotionEvent(hover); hover.recycle()
 
-            val eventDown = MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, 1, arrayOf(propM), arrayOf(coordM), 0, 0, 1f, 1f, 0, 0, InputDevice.SOURCE_MOUSE, 0)
+            val eventDown = MotionEvent.obtain(
+                downTime,
+                downTime,
+                MotionEvent.ACTION_DOWN,
+                1,
+                arrayOf(propM),
+                arrayOf(coordM),
+                0,
+                0,
+                1f,
+                1f,
+                0,
+                0,
+                InputDevice.SOURCE_MOUSE,
+                0
+            )
             wv.dispatchTouchEvent(eventDown)
 
             mainHandler.postDelayed({
                 coordM.x += 1f; coordM.y += 1f
-                val eventUp = MotionEvent.obtain(downTime, SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 1, arrayOf(propM), arrayOf(coordM), 0, 0, 1f, 1f, 0, 0, InputDevice.SOURCE_MOUSE, 0)
+                val eventUp = MotionEvent.obtain(
+                    downTime,
+                    SystemClock.uptimeMillis(),
+                    MotionEvent.ACTION_UP,
+                    1,
+                    arrayOf(propM),
+                    arrayOf(coordM),
+                    0,
+                    0,
+                    1f,
+                    1f,
+                    0,
+                    0,
+                    InputDevice.SOURCE_MOUSE,
+                    0
+                )
                 wv.dispatchTouchEvent(eventUp)
                 eventDown.recycle(); eventUp.recycle()
                 CookieManager.getInstance().flush()
@@ -502,7 +629,8 @@ class WebViewResolver(private val context: Context) {
                 webView = null
                 virtualCursor = null
                 Log.d(TAG, "[WebView] Closed")
-            } catch (e: Exception) { }
+            } catch (e: Exception) {
+            }
         }
 
         if (Looper.myLooper() == Looper.getMainLooper()) {
@@ -512,3 +640,4 @@ class WebViewResolver(private val context: Context) {
         }
     }
 }
+


### PR DESCRIPTION
## Summary

This updates `AnimeOnlineNinjaProvider` to be more reliable against Cloudflare protection and more accurate when resolving content from the site.

## Changes

- Added Cronet-based page and JSON fetching for better compatibility with the site.
- Added Cloudflare clearance handling with WebView fallback when the provider is challenged.
- Kept the in-memory document cache but added TTL-based invalidation.
- Sync clearance cookies with `CookieManager` so expired cookies are not reused.
- Improved episode, season, and parent-show resolution so episode/season pages resolve back to the canonical TV show.
- Refined search and archive parsing to avoid picking up sidebar or unrelated items.
- Improved synopsis extraction and title cleanup.
- Improved artwork handling and server resolution for provider pages.
- Added safer server prioritization using the preferred server setting when available.

## Notes

- This keeps the provider aligned with the current site structure.
- It also reduces false positives and stale results when browsing or opening episodes.