### PR TITLE
Add Blocking on Popups and Add Loading Indicator

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/extractors/StreamWishExtractor.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/extractors/StreamWishExtractor.kt
@@ -3,6 +3,7 @@ package com.streamflixreborn.streamflix.extractors
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
+import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -189,6 +190,20 @@ open class StreamWishExtractor : Extractor() {
                     val webView = WebView(context)
                     webView.settings.javaScriptEnabled = true
                     webView.settings.domStorageEnabled = true
+                    // Ad-supported embed pages (this is the host CineHax's "streamwish"
+                    // servers resolve to, among others) try to spawn popups/new tabs via
+                    // window.open() during this redirect hop - block that instead of letting
+                    // it surface as an ad to the user.
+                    webView.settings.javaScriptCanOpenWindowsAutomatically = false
+                    webView.settings.setSupportMultipleWindows(false)
+                    webView.webChromeClient = object : WebChromeClient() {
+                        override fun onCreateWindow(
+                            view: WebView?,
+                            isDialog: Boolean,
+                            isUserGesture: Boolean,
+                            resultMsg: android.os.Message?,
+                        ): Boolean = false
+                    }
 
                     webView.webViewClient = object : WebViewClient() {
                         override fun shouldOverrideUrlLoading(

--- a/app/src/main/java/com/streamflixreborn/streamflix/extractors/UpzoneExtractor.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/extractors/UpzoneExtractor.kt
@@ -3,6 +3,7 @@ package com.streamflixreborn.streamflix.extractors
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
+import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -163,6 +164,18 @@ class UpzoneExtractor : Extractor() {
                     webView.settings.javaScriptEnabled = true
                     webView.settings.domStorageEnabled = true
                     webView.settings.userAgentString = userAgent
+                    // Block popup/new-tab ads the embed page tries to spawn via window.open()
+                    // during this redirect hop.
+                    webView.settings.javaScriptCanOpenWindowsAutomatically = false
+                    webView.settings.setSupportMultipleWindows(false)
+                    webView.webChromeClient = object : WebChromeClient() {
+                        override fun onCreateWindow(
+                            view: WebView?,
+                            isDialog: Boolean,
+                            isUserGesture: Boolean,
+                            resultMsg: android.os.Message?,
+                        ): Boolean = false
+                    }
 
                     webView.webViewClient = object : WebViewClient() {
                         override fun shouldOverrideUrlLoading(

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
@@ -353,6 +353,7 @@ class PlayerMobileFragment : Fragment() {
                     }
 
                     is PlayerViewModel.State.LoadingVideo -> {
+                        binding.tvResolvingServer.visibility = View.VISIBLE
                         player.setMediaItem(
                             MediaItem.Builder()
                                 .setUri("".toUri())
@@ -366,6 +367,7 @@ class PlayerMobileFragment : Fragment() {
                     }
 
                     is PlayerViewModel.State.SuccessLoadingVideo -> {
+                        binding.tvResolvingServer.visibility = View.GONE
                         PlayerSettingsView.Settings.ExtraBuffering.init(state.video.extraBuffering)
                         PlayerSettingsView.Settings.SoftwareDecoder.init(false)
                         displayVideo(state.video, state.server)
@@ -376,6 +378,7 @@ class PlayerMobileFragment : Fragment() {
                         if (nextServer != null) {
                             viewModel.getVideo(nextServer)
                         } else {
+                            binding.tvResolvingServer.visibility = View.GONE
                             val providerName = UserPreferences.currentProvider?.name ?: ""
                             val isTmdb = providerName.contains("TMDb", ignoreCase = true)
                             val isAD = providerName.contains("AfterDark", ignoreCase = true)

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
@@ -383,6 +383,7 @@ class PlayerTvFragment : Fragment() {
                         }
 
                         is PlayerViewModel.State.LoadingVideo -> {
+                            binding.tvResolvingServer.visibility = View.VISIBLE
                             player.setMediaItem(
                                 MediaItem.Builder()
                                     .setUri("".toUri())
@@ -396,6 +397,7 @@ class PlayerTvFragment : Fragment() {
                         }
 
                         is PlayerViewModel.State.SuccessLoadingVideo -> {
+                            binding.tvResolvingServer.visibility = View.GONE
                             PlayerSettingsView.Settings.ExtraBuffering.init(state.video.extraBuffering)
                             PlayerSettingsView.Settings.SoftwareDecoder.init(false)
                             displayVideo(state.video, state.server)
@@ -406,6 +408,7 @@ class PlayerTvFragment : Fragment() {
                             if (nextServer != null) {
                                 viewModel.getVideo(nextServer)
                             } else {
+                                binding.tvResolvingServer.visibility = View.GONE
                                 val providerName = UserPreferences.currentProvider?.name ?: ""
                                 val isTmdb = providerName.contains("TMDb", ignoreCase = true)
                                 val isAD = providerName.contains("AfterDark", ignoreCase = true)

--- a/app/src/main/res/layout/fragment_player_mobile.xml
+++ b/app/src/main/res/layout/fragment_player_mobile.xml
@@ -24,6 +24,25 @@
         app:show_timeout="2000"
         app:surface_type="texture_view" />
 
+    <TextView
+        android:id="@+id/tv_resolving_server"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="#80000000"
+        android:paddingStart="14dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="14dp"
+        android:paddingBottom="8dp"
+        android:text="@string/player_resolving_server"
+        android:textColor="#FFFFFF"
+        android:textSize="13sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/pv_player"
+        app:layout_constraintEnd_toEndOf="@id/pv_player"
+        app:layout_constraintStart_toStartOf="@id/pv_player"
+        app:layout_constraintTop_toTopOf="@id/pv_player"
+        tools:visibility="visible" />
+
     <com.streamflixreborn.streamflix.fragments.player.settings.PlayerSettingsMobileView
         android:id="@+id/settings"
         android:layout_width="300dp"

--- a/app/src/main/res/layout/fragment_player_tv.xml
+++ b/app/src/main/res/layout/fragment_player_tv.xml
@@ -26,6 +26,25 @@
         app:show_timeout="2000"
         app:surface_type="surface_view" />
 
+    <TextView
+        android:id="@+id/tv_resolving_server"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="#80000000"
+        android:paddingStart="14dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="14dp"
+        android:paddingBottom="8dp"
+        android:text="@string/player_resolving_server"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/pv_player"
+        app:layout_constraintEnd_toEndOf="@id/pv_player"
+        app:layout_constraintStart_toStartOf="@id/pv_player"
+        app:layout_constraintTop_toTopOf="@id/pv_player"
+        tools:visibility="visible" />
+
     <com.streamflixreborn.streamflix.fragments.player.settings.PlayerSettingsTvView
         android:id="@+id/settings"
         android:layout_width="350dp"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -50,7 +50,7 @@
     <string name="search_input_hint_iptv">Buscar canales</string>
     <string name="global_search">Búsqueda global</string>
     <string name="search_empty_query">Por favor, introduce un término de búsqueda</string>
-    <string name="searching">Buscando...</string>
+    <string name="searching">Buscando…</string>
     <string name="search_error">Error</string>
     <string name="result">Resultado</string>
     <string name="results">Resultados</string>
@@ -121,6 +121,7 @@
     <string name="player_not_available_it_message">No disponible en servidores italianos, búscalo en TMDB en otros idiomas</string>
     <string name="player_not_available_lang_message">No disponible en %s, búscalo en TMDB en otros idiomas</string>
     <string name="player_retry_later_message">Vídeo no disponible por el momento. Por favor, inténtalo de nuevo más tarde</string>
+    <string name="player_resolving_server">Resolviendo servidor…</string>
     <string name="player_aspect_ratio_fit">Ajustar a la pantalla</string>
     <string name="player_aspect_ratio_fill">Estirar</string>
     <string name="player_aspect_ratio_zoom">Zoom</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="player_next_episode_action">Play now</string>
     <string name="player_next_episode_dismiss">Dismiss</string>
     <string name="player_next_episode_ready">Next episode ready</string>
+    <string name="player_resolving_server">Resolving server…</string>
     <string name="player_next_episode_autoplay_in">Playing next in %ds</string>
     <string name="player_aspect_ratio_fit">Fit to screen</string>
     <string name="player_aspect_ratio_fill">Stretch</string>


### PR DESCRIPTION
# fix: block WebView popups and show a resolving indicator to improve playback UX

## Summary
Two related fixes that came out of investigating reports of ad popups appearing during video playback:

1. - [x] **Popup blocking in extractor WebViews** — `StreamWishExtractor` and `UpzoneExtractor` each open a real WebView (JS enabled) to resolve a redirect on the embed page. Neither had any popup protection, so `window.open()` calls from ad scripts could spawn new windows/tabs. Added `onCreateWindow` returning `false`, plus `setSupportMultipleWindows(false)` and `javaScriptCanOpenWindowsAutomatically = false` to both — mirroring protection that already existed in `WebViewResolver.kt` (used elsewhere for Cloudflare-bypass) but was never wired into the extractor layer.
2. - [x] **"Resolving server…" indicator** — while `PlayerViewModel` is in `State.LoadingVideo`, both player screens showed nothing but a blank `MediaItem`. Added a small `TextView` that appears during that state and disappears on success or once all servers are exhausted.

## Files
- - [x] `StreamWishExtractor.kt`, `UpzoneExtractor.kt`
- - [x] `PlayerMobileFragment.kt`, `PlayerTvFragment.kt`
- - [x] `fragment_player_mobile.xml`, `fragment_player_tv.xml`
- - [x] `values/strings.xml`, `values-es/strings.xml`

## Why this is shared, not provider-specific
StreamWish and Upzone are used by dozens of providers across the app, not just CineHax — this improves playback UX app-wide.

## How to test
- - [x] **Popup block:** play any title that resolves to a StreamWish or Upzone server (CineHax reliably surfaces "Streamwish" / "Streamwish 2") and confirm no new tab/window opens while it loads.
- - [x] **Loading indicator:** play any title on any provider and confirm "Resolving server…" briefly appears over the player while it fetches the video, then disappears once playback starts.
