### PR TITLE
Fix TV search crash for results without a provider

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/search/SearchTvFragment.kt
@@ -50,21 +50,13 @@ class SearchTvFragment : Fragment() {
     private val appAdapter by lazy {
         AppAdapter().apply {
             onMovieClickListener = { movie ->
-
-                if (movie.providerName != UserPreferences.currentProvider?.name) {
-                    UserPreferences.currentProvider = Provider.providers.keys.find { it.name == movie.providerName }
-                    Toast.makeText(requireContext(), getString(R.string.switching_to_provider, movie.providerName), Toast.LENGTH_SHORT).show()
-                }
+                switchProviderIfNeeded(movie.providerName)
                 findNavController().navigate(
                     SearchTvFragmentDirections.actionSearchToMovie(id = movie.id)
                 )
             }
             onTvShowClickListener = { tvShow ->
-
-                if (tvShow.providerName != UserPreferences.currentProvider?.name) {
-                    UserPreferences.currentProvider = Provider.providers.keys.find { it.name == tvShow.providerName }
-                    Toast.makeText(requireContext(), getString(R.string.switching_to_provider, tvShow.providerName), Toast.LENGTH_SHORT).show()
-                }
+                switchProviderIfNeeded(tvShow.providerName)
                 findNavController().navigate(
                     SearchTvFragmentDirections.actionSearchToTvShow(
                         id = tvShow.id,
@@ -77,6 +69,19 @@ class SearchTvFragment : Fragment() {
     }
 
     private lateinit var voiceHelper: VoiceRecognitionHelper
+
+    private fun switchProviderIfNeeded(providerName: String?) {
+        val targetName = providerName?.takeIf { it.isNotBlank() } ?: return
+        if (targetName == UserPreferences.currentProvider?.name) return
+
+        val targetProvider = Provider.providers.keys.find { it.name == targetName } ?: return
+        UserPreferences.currentProvider = targetProvider
+        Toast.makeText(
+            requireContext(),
+            getString(R.string.switching_to_provider, targetName),
+            Toast.LENGTH_SHORT,
+        ).show()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?


### PR DESCRIPTION
## What's changed

- Prevents TV Search from clearing the active provider when opening a normal search result that does not contain a `providerName`.
- Applies the same handling to both movie and TV show results.
- Only switches providers when a result contains a non-blank provider name that resolves to a registered provider.
- Preserves the existing Global Search behavior of switching to the provider that returned the selected result.
- Prevents missing or unresolved provider names from replacing the current provider.

## Why this fix was needed

A regression on current `main` can cause StreamFlix to crash when a normal TV search result is opened.

Normal provider searches and Global Search use the same TV result click callbacks, but their results are not populated in the same way.

Global Search explicitly stamps movie and TV show results with the provider that returned them. This allows StreamFlix to switch providers before opening a result from another provider.

Normal provider search results do not need that metadata because they already belong to the currently selected provider, so their `providerName` can be `null`.

The unsafe provider-switch callback was introduced on October 12, 2025 in commit `14a3392f` (`Refactor: Centralize navigation logic for TV search results`) and retained by the follow-up refactor `f62dd1df`.

Previously, normal TV grid items still navigated through the movie/TV-show ViewHolder's existing guarded provider-checking path, which ignored missing or blank provider names before navigating.

PR #19 (`Favorites screen`) added shared click-listener delegation to the movie and TV-show ViewHolders. When one of these listeners is supplied, it is invoked before the ViewHolder's existing provider-checking/navigation path.

TV Search supplies those listeners.

As a result, after PR #19 was merged, normal TV search results began reaching `SearchTvFragment`'s pre-existing unsafe provider-switch callback directly.

That exposed the existing unsafe assumption in the callback:

1. Select a provider such as TMDb.
2. Perform a normal search, for example `Dune: Part Two`.
3. Open the normal search result.
4. The result has no `providerName`, because it already belongs to the active provider.
5. The TV Search callback compares that missing value against the current provider name.
6. It attempts to resolve the missing provider name.
7. The lookup returns `null`.
8. `UserPreferences.currentProvider` is replaced with `null`.
9. StreamFlix displays `Switching to null`.
10. Navigation continues into the detail flow, where an active provider is expected, causing the app to close/crash.

PR #19's listener delegation is not inherently incorrect; it is needed by screens such as Favorites that provide their own item interactions.

The regression was caused by that newer shared click path exposing the pre-existing unsafe assumption in TV Search.

This fix hardens the TV Search callback so it correctly handles both kinds of results regardless of which shared ViewHolder click path invokes it.

## Root cause

The failure was an integration regression between:

- the TV Search provider-switch callback introduced in October 2025 for Global Search, and
- the shared movie/TV-show click-listener delegation introduced by PR #19.

The existing callback assumed every result reaching it contained valid provider metadata.

That assumption is true for Global Search results, which are stamped with their origin provider, but false for normal provider search results.

Before PR #19, normal TV search results navigated through the ViewHolder's guarded provider-switch path, so the unsafe callback was not reached for that normal flow.

After PR #19, the injected Search listener took precedence, causing normal results to reach the callback and exposing the bug.

The correct fix is therefore to make `SearchTvFragment` treat provider metadata as optional and only switch providers when a real registered provider is explicitly identified.

## How the bug was discovered

This regression was found while physically testing a separate StreamFlix feature/fix on Google TV.

That work was based on the newly updated upstream `main`.

During its normal TV test flow I:

1. Selected TMDb.
2. Searched for `Dune: Part Two`.
3. Opened the normal search result.

Instead of opening the movie details, StreamFlix displayed:

`Switching to null`

and then closed/crashed.

Because the failure occurred before the separate feature being tested was reached, it was investigated independently against current upstream.

Tracing the actual click path showed that normal TV search results were now being routed through `SearchTvFragment`'s shared result callback.

The normal result had no `providerName`, and that callback replaced the active provider with the result of a failed provider lookup.

Comparing the behavior with the pre-merge path showed that PR #19 caused normal TV Search results to begin using the pre-existing callback introduced in October 2025, exposing the latent null-provider bug.

This fix was therefore kept separate from the feature during whose physical testing the regression was discovered.

## Global Search

Existing Global Search provider-switching behavior is preserved.

Global Search results are stamped with the provider that returned them.

When a result identifies a different registered provider, StreamFlix still switches to that provider before opening the movie or TV show.

The fix only prevents:

- normal unstamped search results,
- blank provider names, and
- unresolved provider names

from being interpreted as valid provider switches.

## Implementation

Provider switching now occurs only when all of the following are true:

- the result contains a non-blank `providerName`;
- that provider differs from the currently selected provider; and
- the name resolves to an actual registered StreamFlix provider.

Otherwise the current provider is preserved and navigation continues normally.

This also prevents malformed or stale provider metadata from clearing the active provider.

## Scope

This change is limited to TV Search result provider switching in:

- `SearchTvFragment.kt`

It does not change:

- Mobile Search.
- Provider search implementations.
- Global Search result collection or grouping.
- The shared ViewHolder listener mechanism introduced by PR #19.
- Favorites behavior.
- TMDb catalog behavior.
- Provider selection UI.
- Playback or extractors.
- Subtitle or audio behavior.
- The separate feature/fix during whose physical testing this regression was discovered.

## Verification

The updated code has been verified with:

- Android TV unit-test task.
- Android TV debug APK build with `APP_LAYOUT=tv`.
- Physical Google TV testing with a D-pad remote.

Physical TV testing confirmed:

- Normal TMDb movie search results open without displaying `Switching to null`.
- Normal TMDb TV show search results open successfully.
- Multiple normal movie searches open without changing the active provider.
- Global Search results from another registered provider still switch to the correct provider.
- The selected provider updates correctly after a legitimate Global Search provider switch.
- D-pad selection and navigation continue to work normally.

Tested titles included:

- `Dune: Part Two`
- `The Last of Us`
- `Oppenheimer`