### PR TITLE
Detect subtitles

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
@@ -441,6 +441,9 @@ class PlayerMobileFragment : Fragment() {
                                 .build()
                         )
                         UserPreferences.subtitleName = (state.subtitle.languageName ?: fileName).substringBefore(" ")
+                        state.subtitle.languageName?.let { lang ->
+                            UserPreferences.preferredSubtitleLanguage = lang
+                        }
                         player.seekTo(currentPosition)
                         player.play()
                     }
@@ -481,6 +484,10 @@ class PlayerMobileFragment : Fragment() {
                                 .build()
                         )
                         UserPreferences.subtitleName = (state.subtitle.releaseName ?: state.subtitle.name ?: fileName).substringBefore(" ")
+                        val subDLLang = state.subtitle.lang ?: state.subtitle.language
+                        if (subDLLang != null) {
+                            UserPreferences.preferredSubtitleLanguage = subDLLang
+                        }
                         player.seekTo(currentPosition)
                         player.play()
                     }
@@ -1030,6 +1037,48 @@ class PlayerMobileFragment : Fragment() {
             }
         }
         player.addListener(object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                super.onPlaybackStateChanged(playbackState)
+
+                if (playbackState == Player.STATE_READY) {
+                    val preferredSubLang = UserPreferences.preferredSubtitleLanguage
+                    if (!preferredSubLang.isNullOrEmpty()) {
+                        val trackGroups = player.currentTracks.groups.filter { it.type == C.TRACK_TYPE_TEXT }
+                        for (group in trackGroups) {
+                            for (i in 0 until group.length) {
+                                val format = group.getTrackFormat(i)
+                                if (format.language.equals(preferredSubLang, ignoreCase = true)) {
+                                    player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
+                                        .setOverrideForType(
+                                            androidx.media3.common.TrackSelectionOverride(
+                                                group.mediaTrackGroup,
+                                                i
+                                            )
+                                        )
+                                        .build()
+                                    return
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
+                super.onTracksChanged(tracks)
+                val textGroups = tracks.groups.filter { it.type == C.TRACK_TYPE_TEXT }
+                for (group in textGroups) {
+                    for (i in 0 until group.length) {
+                        if (group.isTrackSelected(i)) {
+                            val lang = group.getTrackFormat(i).language
+                            if (!lang.isNullOrBlank() && lang != "und" && UserPreferences.preferredSubtitleLanguage != lang) {
+                                UserPreferences.preferredSubtitleLanguage = lang
+                            }
+                        }
+                    }
+                }
+            }
+
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 super.onIsPlayingChanged(isPlaying)
                 binding.pvPlayer.keepScreenOn = isPlaying || UserPreferences.keepScreenOnWhenPaused

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
@@ -487,6 +487,9 @@ class PlayerTvFragment : Fragment() {
                                 )
                                 UserPreferences.subtitleName =
                                     (state.subtitle.languageName ?: fileName).substringBefore(" ")
+                                state.subtitle.languageName?.let { lang ->
+                                    UserPreferences.preferredSubtitleLanguage = lang
+                                }
                                 player.seekTo(currentPosition)
                                 player.play()
                             }
@@ -544,6 +547,10 @@ class PlayerTvFragment : Fragment() {
                                 UserPreferences.subtitleName =
                                     (state.subtitle.releaseName ?: state.subtitle.name
                                     ?: fileName).substringBefore(" ")
+                                val subDLLang = state.subtitle.lang ?: state.subtitle.language
+                                if (subDLLang != null) {
+                                    UserPreferences.preferredSubtitleLanguage = subDLLang
+                                }
                                 player.seekTo(currentPosition)
                                 player.play()
                             }
@@ -1174,8 +1181,31 @@ class PlayerTvFragment : Fragment() {
                     super.onPlaybackStateChanged(playbackState)
 
                     if (playbackState == Player.STATE_READY) {
+                        if (!::player.isInitialized) return
+
                         binding.pvPlayer.controller.binding.exoPlayPause.nextFocusDownId = -1
-                        val videoFormat = player.videoFormat
+
+                        val preferredSubLang = UserPreferences.preferredSubtitleLanguage
+                        if (!preferredSubLang.isNullOrEmpty()) {
+                            val trackGroups = player.currentTracks.groups.filter { it.type == C.TRACK_TYPE_TEXT }
+                            for (group in trackGroups) {
+                                for (i in 0 until group.length) {
+                                    val format = group.getTrackFormat(i)
+                                    if (format.language.equals(preferredSubLang, ignoreCase = true)) {
+                                        player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
+                                            .setOverrideForType(
+                                                androidx.media3.common.TrackSelectionOverride(
+                                                    group.mediaTrackGroup,
+                                                    i
+                                                )
+                                            )
+                                            .build()
+                                        return
+                                    }
+                                }
+                            }
+                        }
+                        player.play()
                         updatePlayerScale()
                     }
                 }
@@ -1184,6 +1214,17 @@ class PlayerTvFragment : Fragment() {
                     super.onTracksChanged(tracks)
                     val videoGroups = tracks.groups.filter { it.type == C.TRACK_TYPE_VIDEO }
                     val videoTracks = videoGroups.sumOf { it.length }
+                    val textGroups = tracks.groups.filter { it.type == C.TRACK_TYPE_TEXT }
+                    for (group in textGroups) {
+                        for (i in 0 until group.length) {
+                            if (group.isTrackSelected(i)) {
+                                val lang = group.getTrackFormat(i).language
+                                if (!lang.isNullOrBlank() && lang != "und" && UserPreferences.preferredSubtitleLanguage != lang) {
+                                    UserPreferences.preferredSubtitleLanguage = lang
+                                }
+                            }
+                        }
+                    }
                     val selectedHeights = buildList {
                         videoGroups.forEach { group ->
                             for (i in 0 until group.length) {

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/UserPreferences.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/UserPreferences.kt
@@ -439,6 +439,10 @@ object UserPreferences {
             Key.FAVORITE_PROVIDERS.setStringSet(value)
         }
 
+    var preferredSubtitleLanguage: String?
+        get() = Key.PREFERRED_SUBTITLE_LANGUAGE.getString()
+        set(value) = Key.PREFERRED_SUBTITLE_LANGUAGE.setString(value)
+
     private enum class Key {
         APP_LAYOUT,
         CURRENT_LANGUAGE,
@@ -481,7 +485,9 @@ object UserPreferences {
         BYPASS_WS_ADVERTISED_HOST,
         UPDATE_CHECK_ENABLED,
         PROVIDER_LANGUAGE,
-        FAVORITE_PROVIDERS;
+        FAVORITE_PROVIDERS,
+
+        PREFERRED_SUBTITLE_LANGUAGE;
 
         fun getStringSet(): Set<String>? = when {
             prefs.contains(name) -> prefs.getStringSet(name, null)


### PR DESCRIPTION
Added preferredSubtitleLanguage to UserPreferences to store the user's selected subtitle language.

The player now initiates video playback instantly. Subtitle selection is performed in a non-blocking manner once the video buffer is ready.

Users no longer need to manually select subtitles for every episode; their preference is maintained automatically.