### PR TITLE
Feat: Add content ratings and 5-second player overlay

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/MovieViewHolder.kt
@@ -768,6 +768,11 @@ class MovieViewHolder(
             }
         }
 
+        binding.tvMovieContentRating.apply {
+            text = movie.contentRating?.certification
+            visibility = if (text.isNullOrEmpty()) View.GONE else View.VISIBLE
+        }
+
         binding.tvMovieRuntime.apply {
             text = movie.runtime?.let {
                 val hours = it / 60
@@ -897,6 +902,11 @@ class MovieViewHolder(
                 text.isNullOrEmpty() -> View.GONE
                 else -> View.VISIBLE
             }
+        }
+
+        binding.tvMovieContentRating.apply {
+            text = movie.contentRating?.certification
+            visibility = if (text.isNullOrEmpty()) View.GONE else View.VISIBLE
         }
 
         binding.tvMovieRuntime.apply {

--- a/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/adapters/viewholders/TvShowViewHolder.kt
@@ -633,6 +633,11 @@ class TvShowViewHolder(
             isVisible = !text.isNullOrEmpty()
         }
 
+        binding.tvTvShowContentRating.apply {
+            text = tvShow.contentRating?.certification
+            isVisible = !text.isNullOrEmpty()
+        }
+
         binding.tvTvShowRuntime.apply {
             text = tvShow.runtime?.let {
                 val hours = it / 60
@@ -764,6 +769,11 @@ class TvShowViewHolder(
 
         binding.tvTvShowReleased.apply {
             text = tvShow.released?.format("yyyy")
+            isVisible = !text.isNullOrEmpty()
+        }
+
+        binding.tvTvShowContentRating.apply {
+            text = tvShow.contentRating?.certification
             isVisible = !text.isNullOrEmpty()
         }
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/movie/MovieViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/movie/MovieViewModel.kt
@@ -8,6 +8,7 @@ import com.streamflixreborn.streamflix.models.Movie
 import com.streamflixreborn.streamflix.models.TvShow
 import com.streamflixreborn.streamflix.utils.EpisodeManager
 import com.streamflixreborn.streamflix.utils.UserPreferences
+import com.streamflixreborn.streamflix.utils.ContentRatingRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
+import java.util.Calendar
 
 class MovieViewModel(id: String, private val database: AppDatabase) : ViewModel() {
 
@@ -98,6 +100,14 @@ class MovieViewModel(id: String, private val database: AppDatabase) : ViewModel(
 
         try {
             val movie = UserPreferences.currentProvider!!.getMovie(id)
+            movie.contentRating = ContentRatingRepository.movie(
+                tmdbId = id.toIntOrNull().takeIf {
+                    UserPreferences.currentProvider?.name?.contains("TMDb", ignoreCase = true) == true
+                },
+                title = movie.title,
+                year = movie.released?.get(Calendar.YEAR),
+                language = UserPreferences.currentProvider?.language,
+            )
 
             database.movieDao().getById(id)?.let { movieDb ->
                 movie.merge(movieDb)

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
@@ -93,6 +93,7 @@ import com.streamflixreborn.streamflix.utils.DnsResolver
 import com.streamflixreborn.streamflix.utils.NetworkClient
 import com.streamflixreborn.streamflix.utils.EpisodeManager
 import com.streamflixreborn.streamflix.utils.PlayerGestureHelper
+import com.streamflixreborn.streamflix.utils.ContentRatingOverlayPolicy
 import com.streamflixreborn.streamflix.utils.UserDataCache.toEpisode
 import com.streamflixreborn.streamflix.utils.UserDataCache.toMovie
 import kotlinx.coroutines.Dispatchers
@@ -140,6 +141,7 @@ class PlayerMobileFragment : Fragment() {
     private var nextEpisodePrefetchTargetId: String? = null
     private var nextEpisodePrefetchJob: Job? = null
     private var nextEpisodeOverlayDismissed = false
+    private var contentRatingOverlayJob: Job? = null
 
     private val bypassWebViewLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -271,6 +273,7 @@ class PlayerMobileFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         initializePlayer(false)
         initializeVideo()
+        observeContentRating()
         gestureHelper = PlayerGestureHelper(
             requireContext(), 
             binding.pvPlayer, 
@@ -548,6 +551,7 @@ class PlayerMobileFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         nextEpisodePrefetchJob?.cancel()
+        contentRatingOverlayJob?.cancel()
         val window = requireActivity().window
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
@@ -566,6 +570,32 @@ class PlayerMobileFragment : Fragment() {
         } catch (ignored: Exception) {}
         _binding = null
         isSetupDone = false
+    }
+
+    private fun observeContentRating() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.contentRating.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+                .collect { state ->
+                    contentRatingOverlayJob?.cancel()
+                    binding.tvContentRatingBadge.animate().cancel()
+                    when (state) {
+                        is PlayerViewModel.RatingState.Available -> {
+                            val badge = binding.tvContentRatingBadge
+                            badge.text = state.rating.certification
+                            badge.alpha = 0f
+                            badge.visibility = View.VISIBLE
+                            badge.animate().alpha(1f).setDuration(180L).start()
+                            contentRatingOverlayJob = viewLifecycleOwner.lifecycleScope.launch {
+                                delay(ContentRatingOverlayPolicy.DISPLAY_DURATION_MS - ContentRatingOverlayPolicy.FADE_OUT_DURATION_MS)
+                                badge.animate().alpha(0f).setDuration(ContentRatingOverlayPolicy.FADE_OUT_DURATION_MS).withEndAction {
+                                    if (_binding != null) badge.visibility = View.GONE
+                                }.start()
+                            }
+                        }
+                        else -> binding.tvContentRatingBadge.visibility = View.GONE
+                    }
+                }
+        }
     }
 
     fun onBackPressed(): Boolean = when {

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerMobileFragment.kt
@@ -142,6 +142,8 @@ class PlayerMobileFragment : Fragment() {
     private var nextEpisodePrefetchJob: Job? = null
     private var nextEpisodeOverlayDismissed = false
     private var contentRatingOverlayJob: Job? = null
+    private var observedContentRatingMediaKey: String? = null
+    private var displayedContentRatingMediaKey: String? = null
 
     private val bypassWebViewLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -576,10 +578,21 @@ class PlayerMobileFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.contentRating.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
                 .collect { state ->
+                    if (state is PlayerViewModel.RatingState.Available &&
+                        state.mediaKey == displayedContentRatingMediaKey
+                    ) return@collect
+                    if (state is PlayerViewModel.RatingState.Loading &&
+                        state.mediaKey != observedContentRatingMediaKey
+                    ) {
+                        observedContentRatingMediaKey = state.mediaKey
+                        displayedContentRatingMediaKey = null
+                    }
                     contentRatingOverlayJob?.cancel()
                     binding.tvContentRatingBadge.animate().cancel()
                     when (state) {
                         is PlayerViewModel.RatingState.Available -> {
+                            observedContentRatingMediaKey = state.mediaKey
+                            displayedContentRatingMediaKey = state.mediaKey
                             val badge = binding.tvContentRatingBadge
                             badge.text = state.rating.certification
                             badge.alpha = 0f

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
@@ -80,6 +80,7 @@ import com.streamflixreborn.streamflix.utils.NetworkClient
 import com.streamflixreborn.streamflix.utils.EpisodeManager
 import com.streamflixreborn.streamflix.utils.MediaServer
 import com.streamflixreborn.streamflix.utils.PlayerGestureHelper
+import com.streamflixreborn.streamflix.utils.ContentRatingOverlayPolicy
 import com.streamflixreborn.streamflix.utils.UserPreferences
 import com.streamflixreborn.streamflix.utils.UserDataCache
 import com.streamflixreborn.streamflix.utils.dp
@@ -161,6 +162,7 @@ class PlayerTvFragment : Fragment() {
     private var nextEpisodePrefetchTargetId: String? = null
     private var nextEpisodePrefetchJob: Job? = null
     private var nextEpisodeOverlayDismissed = false
+    private var contentRatingOverlayJob: Job? = null
     private val chooserReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
@@ -259,6 +261,7 @@ class PlayerTvFragment : Fragment() {
 
         initializePlayer(false)
         initializeVideo()
+        observeContentRating()
         binding.pvPlayer.onMediaPreviousClicked = ::handleMediaPrevious
         binding.pvPlayer.onMediaNextClicked = ::handleMediaNext
         gestureHelper = PlayerGestureHelper(
@@ -618,6 +621,7 @@ class PlayerTvFragment : Fragment() {
         override fun onDestroyView() {
             super.onDestroyView()
             nextEpisodePrefetchJob?.cancel()
+            contentRatingOverlayJob?.cancel()
             clearBypassSession(dismissDialog = true)
             releasePlayer()
             try {
@@ -626,6 +630,32 @@ class PlayerTvFragment : Fragment() {
             }
             _binding = null
             isSetupDone = false
+        }
+
+        private fun observeContentRating() {
+            viewLifecycleOwner.lifecycleScope.launch {
+                viewModel.contentRating.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+                    .collect { state ->
+                        contentRatingOverlayJob?.cancel()
+                        binding.tvContentRatingBadge.animate().cancel()
+                        when (state) {
+                            is PlayerViewModel.RatingState.Available -> {
+                                val badge = binding.tvContentRatingBadge
+                                badge.text = state.rating.certification
+                                badge.alpha = 0f
+                                badge.visibility = View.VISIBLE
+                                badge.animate().alpha(1f).setDuration(180L).start()
+                                contentRatingOverlayJob = viewLifecycleOwner.lifecycleScope.launch {
+                                    delay(ContentRatingOverlayPolicy.DISPLAY_DURATION_MS - ContentRatingOverlayPolicy.FADE_OUT_DURATION_MS)
+                                    badge.animate().alpha(0f).setDuration(ContentRatingOverlayPolicy.FADE_OUT_DURATION_MS).withEndAction {
+                                        if (_binding != null) badge.visibility = View.GONE
+                                    }.start()
+                                }
+                            }
+                            else -> binding.tvContentRatingBadge.visibility = View.GONE
+                        }
+                    }
+            }
         }
 
     fun onBackPressed(): Boolean = when {

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerTvFragment.kt
@@ -163,6 +163,8 @@ class PlayerTvFragment : Fragment() {
     private var nextEpisodePrefetchJob: Job? = null
     private var nextEpisodeOverlayDismissed = false
     private var contentRatingOverlayJob: Job? = null
+    private var observedContentRatingMediaKey: String? = null
+    private var displayedContentRatingMediaKey: String? = null
     private val chooserReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
@@ -636,10 +638,21 @@ class PlayerTvFragment : Fragment() {
             viewLifecycleOwner.lifecycleScope.launch {
                 viewModel.contentRating.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
                     .collect { state ->
+                        if (state is PlayerViewModel.RatingState.Available &&
+                            state.mediaKey == displayedContentRatingMediaKey
+                        ) return@collect
+                        if (state is PlayerViewModel.RatingState.Loading &&
+                            state.mediaKey != observedContentRatingMediaKey
+                        ) {
+                            observedContentRatingMediaKey = state.mediaKey
+                            displayedContentRatingMediaKey = null
+                        }
                         contentRatingOverlayJob?.cancel()
                         binding.tvContentRatingBadge.animate().cancel()
                         when (state) {
                             is PlayerViewModel.RatingState.Available -> {
+                                observedContentRatingMediaKey = state.mediaKey
+                                displayedContentRatingMediaKey = state.mediaKey
                                 val badge = binding.tvContentRatingBadge
                                 badge.text = state.rating.certification
                                 badge.alpha = 0f

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerViewModel.kt
@@ -120,8 +120,8 @@ class PlayerViewModel(
                 idsAreTmdb = provider?.name?.contains("TMDb", ignoreCase = true) == true,
             )
             // The key check also protects against non-cooperative/late metadata requests.
-            if (ratingPolicy.accepts(key)) {
-                _contentRating.emit(if (rating == null) RatingState.Hidden else RatingState.Available(key, rating))
+            ratingPolicy.publishIfCurrent(key) {
+                _contentRating.value = if (rating == null) RatingState.Hidden else RatingState.Available(key, rating)
             }
         }
     }

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/player/PlayerViewModel.kt
@@ -6,6 +6,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.streamflixreborn.streamflix.models.Video
+import com.streamflixreborn.streamflix.models.ContentRating
+import com.streamflixreborn.streamflix.utils.ContentRatingRepository
+import com.streamflixreborn.streamflix.utils.ContentRatingOverlayPolicy
 import com.streamflixreborn.streamflix.utils.CustomTabHelper
 import com.streamflixreborn.streamflix.utils.EpisodeManager
 import com.streamflixreborn.streamflix.utils.OpenSubtitles
@@ -17,6 +20,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Job
 import com.streamflixreborn.streamflix.utils.SubDL
 
 class PlayerViewModel(
@@ -32,9 +36,14 @@ class PlayerViewModel(
 
     private val _playPreviousOrNextEpisode = MutableSharedFlow<Video.Type.Episode>()
     val playPreviousOrNextEpisode: SharedFlow<Video.Type.Episode> = _playPreviousOrNextEpisode
+    private val _contentRating = MutableStateFlow<RatingState>(RatingState.Hidden)
+    val contentRating: Flow<RatingState> = _contentRating
+    private var ratingJob: Job? = null
+    private val ratingPolicy = ContentRatingOverlayPolicy()
     init {
         getServers(videoType, id)
         getSubtitles(videoType)
+        resolveContentRating(videoType)
     }
 
     fun playEpisode(direction: Direction) {
@@ -90,8 +99,31 @@ class PlayerViewModel(
         }
     }
     fun playEpisode(episode: Video.Type.Episode) {
+        resolveContentRating(episode)
         getServers(episode, episode.id)
         getSubtitles(episode)
+    }
+
+    fun resolveContentRating(type: Video.Type) {
+        val key = when (type) {
+            is Video.Type.Movie -> "movie:${type.id}"
+            is Video.Type.Episode -> "episode:${type.tvShow.id}:S${type.season.number}:E${type.number}:${type.id}"
+        }
+        if (!ratingPolicy.onMediaChanged(key)) return
+        ratingJob?.cancel()
+        _contentRating.value = RatingState.Loading(key)
+        ratingJob = viewModelScope.launch(Dispatchers.IO) {
+            val provider = UserPreferences.currentProvider
+            val rating = ContentRatingRepository.playing(
+                type,
+                provider?.language,
+                idsAreTmdb = provider?.name?.contains("TMDb", ignoreCase = true) == true,
+            )
+            // The key check also protects against non-cooperative/late metadata requests.
+            if (ratingPolicy.accepts(key)) {
+                _contentRating.emit(if (rating == null) RatingState.Hidden else RatingState.Available(key, rating))
+            }
+        }
     }
 
     private fun getServers(videoType: Video.Type, id: String) = viewModelScope.launch(Dispatchers.IO) {
@@ -250,6 +282,11 @@ class PlayerViewModel(
         data object DownloadingSubDLSubtitle : SubtitleState()
         data class SuccessDownloadingSubDLSubtitle(val subtitle: SubDL.Subtitle, val uri: Uri) : SubtitleState()
         data class FailedDownloadingSubDLSubtitle(val error: Exception, val subtitle: SubDL.Subtitle) : SubtitleState()
+    }
+    sealed class RatingState {
+        data object Hidden : RatingState()
+        data class Loading(val mediaKey: String) : RatingState()
+        data class Available(val mediaKey: String, val rating: ContentRating) : RatingState()
     }
     private var lastVideoType: Video.Type? = null
     private var lastId: String? = null

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/tv_show/TvShowViewModel.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/tv_show/TvShowViewModel.kt
@@ -10,6 +10,7 @@ import com.streamflixreborn.streamflix.models.Season
 import com.streamflixreborn.streamflix.models.TvShow
 import com.streamflixreborn.streamflix.utils.ArtworkRepair
 import com.streamflixreborn.streamflix.utils.UserPreferences
+import com.streamflixreborn.streamflix.utils.ContentRatingRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +21,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
+import java.util.Calendar
 
 class TvShowViewModel(
     id: String,
@@ -228,6 +230,14 @@ class TvShowViewModel(
 
         try {
             val tvShow = UserPreferences.currentProvider!!.getTvShow(id)
+            tvShow.contentRating = ContentRatingRepository.series(
+                tmdbId = id.toIntOrNull().takeIf {
+                    UserPreferences.currentProvider?.name?.contains("TMDb", ignoreCase = true) == true
+                },
+                title = tvShow.title,
+                year = tvShow.released?.get(Calendar.YEAR),
+                language = UserPreferences.currentProvider?.language,
+            )
 
             if (!ArtworkRepair.isRemoteArtworkUrl(tvShow.poster) && ArtworkRepair.isRemoteArtworkUrl(fallbackPoster)) {
                 tvShow.poster = fallbackPoster

--- a/app/src/main/java/com/streamflixreborn/streamflix/models/ContentRating.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/models/ContentRating.kt
@@ -1,0 +1,35 @@
+package com.streamflixreborn.streamflix.models
+
+/** A certification returned by metadata, preserving its official display label. */
+data class ContentRating(
+    val certification: String,
+    val minimumAge: Int? = null,
+    val country: String? = null,
+    val source: String? = null,
+    val scope: Scope,
+) {
+    enum class Scope { MOVIE, EPISODE, SEASON, SERIES }
+
+    companion object {
+        fun mostSpecific(
+            episode: ContentRating?, season: ContentRating?, series: ContentRating?,
+        ): ContentRating? = episode ?: season ?: series
+
+        fun create(
+            certification: String?,
+            minimumAge: Int? = null,
+            country: String? = null,
+            source: String? = null,
+            scope: Scope,
+        ): ContentRating? {
+            val normalized = certification
+                ?.trim()
+                ?.replace('_', '-')
+                ?.replace(Regex("\\s+"), " ")
+                ?.uppercase()
+                ?.takeIf { it.isNotBlank() && it !in setOf("N/A", "NR", "UR", "UNRATED", "NOT RATED", "UNKNOWN") }
+                ?: return null
+            return ContentRating(normalized, minimumAge, country?.uppercase(), source, scope)
+        }
+    }
+}

--- a/app/src/main/java/com/streamflixreborn/streamflix/models/Movie.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/models/Movie.kt
@@ -40,6 +40,9 @@ class Movie(
     override var isFavorite: Boolean = false,
 ) : Show, WatchItem, AppAdapter.Item {
 
+    @Ignore
+    var contentRating: ContentRating? = null
+
     var released = released?.toCalendar()
     var favoritedAtMillis: Long? = null
     var lastPlayedAtMillis: Long? = null
@@ -113,6 +116,7 @@ class Movie(
         isFavorite,
     ).apply {
         lastPlayedAtMillis = this@Movie.lastPlayedAtMillis
+        contentRating = this@Movie.contentRating
     }
 
     override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/com/streamflixreborn/streamflix/models/TvShow.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/models/TvShow.kt
@@ -45,6 +45,9 @@ class TvShow(
     override var isFavorite: Boolean = false,
 ) : Show, AppAdapter.Item {
 
+    @Ignore
+    var contentRating: ContentRating? = null
+
     var released = released?.toCalendar()
     var favoritedAtMillis: Long? = null
     var lastPlayedAtMillis: Long? = null
@@ -148,6 +151,7 @@ class TvShow(
         lastPlayedAtMillis = this@TvShow.lastPlayedAtMillis
         lastPlayedEpisodeId = this@TvShow.lastPlayedEpisodeId
         lastPlayedEpisode = this@TvShow.lastPlayedEpisode
+        contentRating = this@TvShow.contentRating
     }
 
     override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/com/streamflixreborn/streamflix/models/Video.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/models/Video.kt
@@ -33,6 +33,8 @@ data class Video(
             val overview: String?,
             val tvShow: TvShow,
             val season: Season,
+            /** Exact provider certification only; null must fall back to season/series metadata. */
+            val contentRating: String? = null,
         ) : Type(), Serializable {
             @Parcelize
             data class TvShow(
@@ -48,6 +50,8 @@ data class Video(
             data class Season(
                 val number: Int,
                 val title: String?,
+                /** Reliable season-level provider certification, when one is supplied. */
+                val contentRating: String? = null,
             ) : Parcelable, Serializable
         }
     }

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicy.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicy.kt
@@ -2,16 +2,24 @@ package com.streamflixreborn.streamflix.utils
 
 /** Pure state used to ensure only media changes trigger an overlay and stale results are rejected. */
 class ContentRatingOverlayPolicy {
+    @Volatile
     var currentMediaKey: String? = null
         private set
 
+    @Synchronized
     fun onMediaChanged(mediaKey: String): Boolean {
         if (mediaKey == currentMediaKey) return false
         currentMediaKey = mediaKey
         return true
     }
 
-    fun accepts(mediaKey: String): Boolean = currentMediaKey == mediaKey
+    /** Checks the key and publishes while holding the same lock used by [onMediaChanged]. */
+    @Synchronized
+    fun publishIfCurrent(mediaKey: String, publication: () -> Unit): Boolean {
+        if (currentMediaKey != mediaKey) return false
+        publication()
+        return true
+    }
 
     companion object {
         const val DISPLAY_DURATION_MS = 5_000L

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicy.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicy.kt
@@ -1,0 +1,20 @@
+package com.streamflixreborn.streamflix.utils
+
+/** Pure state used to ensure only media changes trigger an overlay and stale results are rejected. */
+class ContentRatingOverlayPolicy {
+    var currentMediaKey: String? = null
+        private set
+
+    fun onMediaChanged(mediaKey: String): Boolean {
+        if (mediaKey == currentMediaKey) return false
+        currentMediaKey = mediaKey
+        return true
+    }
+
+    fun accepts(mediaKey: String): Boolean = currentMediaKey == mediaKey
+
+    companion object {
+        const val DISPLAY_DURATION_MS = 5_000L
+        const val FADE_OUT_DURATION_MS = 350L
+    }
+}

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingRepository.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingRepository.kt
@@ -1,0 +1,63 @@
+package com.streamflixreborn.streamflix.utils
+
+import com.streamflixreborn.streamflix.models.ContentRating
+import com.streamflixreborn.streamflix.models.Video
+import java.util.concurrent.ConcurrentHashMap
+
+/** Single entry point for certification metadata used by details, parental controls and playback. */
+object ContentRatingRepository {
+    private val cache = ConcurrentHashMap<String, ContentRating?>()
+    private val missing = ConcurrentHashMap.newKeySet<String>()
+
+    suspend fun movie(
+        tmdbId: Int?, title: String, year: Int? = null, language: String? = null,
+    ): ContentRating? = cached("movie:${tmdbId ?: title.lowercase()}:${year ?: ""}:US") {
+        tmdbId?.let { TmdbUtils.getMovieContentRatingById(it, language) }
+            ?: TmdbUtils.getMovieContentRating(title, year, language)
+    }
+
+    suspend fun series(
+        tmdbId: Int?, title: String, year: Int? = null, language: String? = null,
+    ): ContentRating? = cached("tv:${tmdbId ?: title.lowercase()}:${year ?: ""}:US") {
+        tmdbId?.let { TmdbUtils.getTvShowContentRatingById(it, language) }
+            ?: TmdbUtils.getTvShowContentRating(title, year, language)
+    }
+
+    /**
+     * Resolves the most specific supplied rating. TMDb currently supplies series ratings only;
+     * callers with a reliable provider episode/season certification may pass it without
+     * misrepresenting a series fallback as episode-specific.
+     */
+    suspend fun episode(
+        seriesTmdbId: Int?, seriesTitle: String, seasonNumber: Int, episodeNumber: Int,
+        episodeCertification: String? = null, seasonCertification: String? = null,
+        language: String? = null,
+    ): ContentRating? {
+        val key = "episode:${seriesTmdbId ?: seriesTitle.lowercase()}:S$seasonNumber:E$episodeNumber:US"
+        return cached(key) {
+            ContentRating.mostSpecific(
+                ContentRating.create(episodeCertification, source = "provider", scope = ContentRating.Scope.EPISODE),
+                ContentRating.create(seasonCertification, source = "provider", scope = ContentRating.Scope.SEASON),
+                series(seriesTmdbId, seriesTitle, language = language),
+            )
+        }
+    }
+
+    suspend fun playing(
+        type: Video.Type, language: String? = null, idsAreTmdb: Boolean = false,
+    ): ContentRating? = when (type) {
+        is Video.Type.Movie -> movie(type.id.toIntOrNull().takeIf { idsAreTmdb }, type.title, type.releaseDate.take(4).toIntOrNull(), language)
+        is Video.Type.Episode -> episode(
+            type.tvShow.id.toIntOrNull().takeIf { idsAreTmdb }, type.tvShow.title, type.season.number, type.number,
+            type.contentRating, type.season.contentRating, language,
+        )
+    }
+
+    private suspend fun cached(key: String, loader: suspend () -> ContentRating?): ContentRating? {
+        cache[key]?.let { return it }
+        if (key in missing) return null
+        val value = runCatching { loader() }.getOrNull()
+        if (value == null) missing += key else cache[key] = value
+        return value
+    }
+}

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingRepository.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/ContentRatingRepository.kt
@@ -11,14 +11,14 @@ object ContentRatingRepository {
 
     suspend fun movie(
         tmdbId: Int?, title: String, year: Int? = null, language: String? = null,
-    ): ContentRating? = cached("movie:${tmdbId ?: title.lowercase()}:${year ?: ""}:US") {
+    ): ContentRating? = cached("movie:${tmdbId ?: title.lowercase()}:${year ?: ""}:${preferenceKey(language)}") {
         tmdbId?.let { TmdbUtils.getMovieContentRatingById(it, language) }
             ?: TmdbUtils.getMovieContentRating(title, year, language)
     }
 
     suspend fun series(
         tmdbId: Int?, title: String, year: Int? = null, language: String? = null,
-    ): ContentRating? = cached("tv:${tmdbId ?: title.lowercase()}:${year ?: ""}:US") {
+    ): ContentRating? = cached("tv:${tmdbId ?: title.lowercase()}:${year ?: ""}:${preferenceKey(language)}") {
         tmdbId?.let { TmdbUtils.getTvShowContentRatingById(it, language) }
             ?: TmdbUtils.getTvShowContentRating(title, year, language)
     }
@@ -33,14 +33,18 @@ object ContentRatingRepository {
         episodeCertification: String? = null, seasonCertification: String? = null,
         language: String? = null,
     ): ContentRating? {
-        val key = "episode:${seriesTmdbId ?: seriesTitle.lowercase()}:S$seasonNumber:E$episodeNumber:US"
-        return cached(key) {
-            ContentRating.mostSpecific(
-                ContentRating.create(episodeCertification, source = "provider", scope = ContentRating.Scope.EPISODE),
-                ContentRating.create(seasonCertification, source = "provider", scope = ContentRating.Scope.SEASON),
-                series(seriesTmdbId, seriesTitle, language = language),
-            )
-        }
+        ContentRating.create(
+            episodeCertification, source = "provider", scope = ContentRating.Scope.EPISODE,
+        )?.let { return it }
+        ContentRating.create(
+            seasonCertification, source = "provider", scope = ContentRating.Scope.SEASON,
+        )?.let { return it }
+
+        val fallbackKey = "episode:${seriesTmdbId ?: seriesTitle.lowercase()}:" +
+            "S$seasonNumber:E$episodeNumber:${preferenceKey(language)}"
+        // Provider metadata is checked before this cache, so a later exact value can never be
+        // masked by a previously cached series fallback.
+        return cached(fallbackKey) { series(seriesTmdbId, seriesTitle, language = language) }
     }
 
     suspend fun playing(
@@ -60,4 +64,11 @@ object ContentRatingRepository {
         if (value == null) missing += key else cache[key] = value
         return value
     }
+
+    internal fun preferenceKey(language: String?): String = language
+        ?.trim()
+        ?.replace('_', '-')
+        ?.uppercase()
+        ?.takeIf { it.isNotBlank() }
+        ?: "DEFAULT"
 }

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/TmdbUtils.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/TmdbUtils.kt
@@ -144,7 +144,8 @@ object TmdbUtils {
     suspend fun getMovieContentRating(title: String, year: Int? = null, language: String? = null): ContentRating? {
         if (!UserPreferences.enableTmdb) return null
         val effectiveYear = year ?: extractYear(title)
-        val key = buildLookupCacheKey("movie-rating", title, effectiveYear, language)
+        val key = buildLookupCacheKey("movie-rating", title, effectiveYear, null) +
+            "|${ContentRatingRepository.preferenceKey(language)}"
         movieContentRatingCache[key]?.let { return it }
         if (key in missingContentRatings) return null
         val value = runCatching {
@@ -174,7 +175,8 @@ object TmdbUtils {
     suspend fun getTvShowContentRating(title: String, year: Int? = null, language: String? = null): ContentRating? {
         if (!UserPreferences.enableTmdb) return null
         val effectiveYear = year ?: extractYear(title)
-        val key = buildLookupCacheKey("tv-rating", title, effectiveYear, language)
+        val key = buildLookupCacheKey("tv-rating", title, effectiveYear, null) +
+            "|${ContentRatingRepository.preferenceKey(language)}"
         tvContentRatingCache[key]?.let { return it }
         if (key in missingContentRatings) return null
         val value = runCatching {
@@ -240,7 +242,7 @@ object TmdbUtils {
 
     suspend fun getMovieContentRatingById(id: Int, language: String? = null): ContentRating? {
         if (!UserPreferences.enableTmdb) return null
-        val key = "movie:$id:US"
+        val key = "movie:$id:${ContentRatingRepository.preferenceKey(language)}"
         movieContentRatingCache[key]?.let { return it }
         if (key in missingContentRatings) return null
         val value = runCatching {
@@ -318,7 +320,7 @@ object TmdbUtils {
 
     suspend fun getTvShowContentRatingById(id: Int, language: String? = null): ContentRating? {
         if (!UserPreferences.enableTmdb) return null
-        val key = "tv:$id:US"
+        val key = "tv:$id:${ContentRatingRepository.preferenceKey(language)}"
         tvContentRatingCache[key]?.let { return it }
         if (key in missingContentRatings) return null
         val value = runCatching {

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/TmdbUtils.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/TmdbUtils.kt
@@ -1,6 +1,7 @@
 package com.streamflixreborn.streamflix.utils
 
 import com.streamflixreborn.streamflix.models.Episode
+import com.streamflixreborn.streamflix.models.ContentRating
 import com.streamflixreborn.streamflix.models.Genre
 import com.streamflixreborn.streamflix.models.Movie
 import com.streamflixreborn.streamflix.models.People
@@ -18,6 +19,9 @@ object TmdbUtils {
     private const val UNKNOWN_AGE_RATING = Int.MIN_VALUE
     private val movieAgeCache = ConcurrentHashMap<String, Int>()
     private val tvAgeCache = ConcurrentHashMap<String, Int>()
+    private val movieContentRatingCache = ConcurrentHashMap<String, ContentRating>()
+    private val tvContentRatingCache = ConcurrentHashMap<String, ContentRating>()
+    private val missingContentRatings = ConcurrentHashMap.newKeySet<String>()
 
     suspend fun getMovie(title: String, year: Int? = null, language: String? = null): Movie? {
         if (!UserPreferences.enableTmdb) return null
@@ -137,6 +141,19 @@ object TmdbUtils {
         return ageRating
     }
 
+    suspend fun getMovieContentRating(title: String, year: Int? = null, language: String? = null): ContentRating? {
+        if (!UserPreferences.enableTmdb) return null
+        val effectiveYear = year ?: extractYear(title)
+        val key = buildLookupCacheKey("movie-rating", title, effectiveYear, language)
+        movieContentRatingCache[key]?.let { return it }
+        if (key in missingContentRatings) return null
+        val value = runCatching {
+            findBestMovieMatch(title, effectiveYear, language)?.let { getMovieContentRatingById(it.id, language) }
+        }.getOrNull()
+        if (value == null) missingContentRatings += key else movieContentRatingCache[key] = value
+        return value
+    }
+
     suspend fun getTvShowAgeRating(title: String, year: Int? = null, language: String? = null): Int? {
         if (!UserPreferences.enableTmdb) return null
 
@@ -152,6 +169,19 @@ object TmdbUtils {
 
         tvAgeCache[cacheKey] = encodeAgeRatingCacheValue(ageRating)
         return ageRating
+    }
+
+    suspend fun getTvShowContentRating(title: String, year: Int? = null, language: String? = null): ContentRating? {
+        if (!UserPreferences.enableTmdb) return null
+        val effectiveYear = year ?: extractYear(title)
+        val key = buildLookupCacheKey("tv-rating", title, effectiveYear, language)
+        tvContentRatingCache[key]?.let { return it }
+        if (key in missingContentRatings) return null
+        val value = runCatching {
+            findBestTvMatch(title, effectiveYear, language)?.let { getTvShowContentRatingById(it.id, language) }
+        }.getOrNull()
+        if (value == null) missingContentRatings += key else tvContentRatingCache[key] = value
+        return value
     }
 
     suspend fun getMovieById(id: Int, language: String? = null): Movie? {
@@ -206,6 +236,23 @@ object TmdbUtils {
 
         movieAgeCache[cacheKey] = encodeAgeRatingCacheValue(ageRating)
         return ageRating
+    }
+
+    suspend fun getMovieContentRatingById(id: Int, language: String? = null): ContentRating? {
+        if (!UserPreferences.enableTmdb) return null
+        val key = "movie:$id:US"
+        movieContentRatingCache[key]?.let { return it }
+        if (key in missingContentRatings) return null
+        val value = runCatching {
+            val details = TMDb3.Movies.details(
+                movieId = id,
+                appendToResponse = listOf(TMDb3.Params.AppendToResponse.Movie.RELEASES_DATES),
+                language = language,
+            )
+            extractMovieContentRating(details, language)
+        }.getOrNull()
+        if (value == null) missingContentRatings += key else movieContentRatingCache[key] = value
+        return value
     }
 
     suspend fun getTvShowById(id: Int, language: String? = null): TvShow? {
@@ -267,6 +314,23 @@ object TmdbUtils {
 
         tvAgeCache[cacheKey] = encodeAgeRatingCacheValue(ageRating)
         return ageRating
+    }
+
+    suspend fun getTvShowContentRatingById(id: Int, language: String? = null): ContentRating? {
+        if (!UserPreferences.enableTmdb) return null
+        val key = "tv:$id:US"
+        tvContentRatingCache[key]?.let { return it }
+        if (key in missingContentRatings) return null
+        val value = runCatching {
+            val details = TMDb3.TvSeries.details(
+                seriesId = id,
+                appendToResponse = listOf(TMDb3.Params.AppendToResponse.Tv.CONTENT_RATING),
+                language = language,
+            )
+            extractTvShowContentRating(details, language)
+        }.getOrNull()
+        if (value == null) missingContentRatings += key else tvContentRatingCache[key] = value
+        return value
     }
 
     private suspend fun findBestMovieMatch(
@@ -536,6 +600,28 @@ object TmdbUtils {
             .maxOrNull()
     }
 
+    private fun extractMovieContentRating(details: TMDb3.Movie.Detail, language: String?): ContentRating? {
+        val releases = details.releaseDates?.results.orEmpty()
+        for (country in buildPreferredCertificationCountries(language)) {
+            val candidates = releases.firstOrNull { it.iso3166.equals(country, true) }?.releaseDates.orEmpty()
+            // Theatrical is the canonical classification; limited/premiere then home releases are fallbacks.
+            candidates.sortedBy { release ->
+                when (release.type) {
+                    TMDb3.Movie.ReleaseType.THEATRICAL -> 0
+                    TMDb3.Movie.ReleaseType.THEATRICAL_LIMITED -> 1
+                    TMDb3.Movie.ReleaseType.PREMIERE -> 2
+                    TMDb3.Movie.ReleaseType.DIGITAL -> 3
+                    TMDb3.Movie.ReleaseType.PHYSICAL -> 4
+                    else -> 5
+                }
+            }.firstNotNullOfOrNull { release ->
+                val label = normalizeCertification(release.certification)
+                ContentRating.create(label, parseAgeRating(label), country, "TMDb", ContentRating.Scope.MOVIE)
+            }?.let { return it }
+        }
+        return null
+    }
+
     private fun extractTvShowAgeRating(details: TMDb3.Tv.Detail, language: String?): Int? {
         val contentRatings = details.contentRatings?.results.orEmpty()
         val preferredCountries = buildPreferredCertificationCountries(language)
@@ -553,6 +639,18 @@ object TmdbUtils {
             .maxOrNull()
     }
 
+    private fun extractTvShowContentRating(details: TMDb3.Tv.Detail, language: String?): ContentRating? {
+        val ratings = details.contentRatings?.results.orEmpty()
+        for (country in buildPreferredCertificationCountries(language)) {
+            ratings.firstNotNullOfOrNull { rating ->
+                if (!rating.iso3166.equals(country, true)) return@firstNotNullOfOrNull null
+                val label = normalizeCertification(rating.rating)
+                ContentRating.create(label, parseAgeRating(label), country, "TMDb", ContentRating.Scope.SERIES)
+            }?.let { return it }
+        }
+        return null
+    }
+
     private fun buildPreferredCertificationCountries(language: String?): List<String> {
         val primary = when (language?.substringBefore('-')?.lowercase()) {
             "de" -> "DE"
@@ -567,9 +665,16 @@ object TmdbUtils {
                 ?.uppercase()
         }
 
-        return listOfNotNull(primary, "US", "GB", "DE", "FR", "ES", "IT", "PT")
+        return listOfNotNull("US", primary, "GB", "DE", "FR", "ES", "IT", "PT")
             .distinct()
     }
+
+    internal fun normalizeCertification(raw: String?): String? = raw
+        ?.trim()
+        ?.replace('_', '-')
+        ?.replace(Regex("\\s+"), " ")
+        ?.uppercase()
+        ?.takeIf { it.isNotBlank() && it !in setOf("N/A", "NR", "UR", "UNRATED", "NOT RATED", "UNKNOWN") }
 
     private fun parseAgeRating(raw: String?): Int? {
         val normalized = raw

--- a/app/src/main/res/drawable/bg_content_rating_badge.xml
+++ b/app/src/main/res/drawable/bg_content_rating_badge.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#CC101010" />
+    <stroke android:width="1dp" android:color="#E6FFFFFF" />
+    <corners android:radius="4dp" />
+    <padding android:left="12dp" android:top="7dp" android:right="12dp" android:bottom="7dp" />
+</shape>

--- a/app/src/main/res/layout/content_movie_mobile.xml
+++ b/app/src/main/res/layout/content_movie_mobile.xml
@@ -115,10 +115,26 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="10dp"
         app:layout_constraintBottom_toTopOf="@id/barrier1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/tv_movie_content_rating"
         app:layout_constraintStart_toEndOf="@id/tv_movie_released"
         app:layout_constraintTop_toBottomOf="@id/tv_movie_title"
         tools:text="# h # min"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/tv_movie_content_rating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="10dp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/barrier1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_movie_runtime"
+        app:layout_constraintTop_toBottomOf="@id/tv_movie_title"
+        tools:text="PG-13"
         tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Barrier
@@ -126,7 +142,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="tv_movie_rating,tv_movie_quality,tv_movie_released,tv_movie_runtime" />
+        app:constraint_referenced_ids="tv_movie_rating,tv_movie_quality,tv_movie_released,tv_movie_runtime,tv_movie_content_rating" />
 
     <TextView
         android:id="@+id/tv_movie_genres"

--- a/app/src/main/res/layout/content_movie_tv.xml
+++ b/app/src/main/res/layout/content_movie_tv.xml
@@ -100,12 +100,27 @@
         tools:text="# h # min"
         tools:visibility="visible" />
 
+    <TextView
+        android:id="@+id/tv_movie_content_rating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="15dp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/barrier1"
+        app:layout_constraintStart_toEndOf="@id/tv_movie_runtime"
+        app:layout_constraintTop_toBottomOf="@id/tv_movie_title"
+        tools:text="PG-13"
+        tools:visibility="visible" />
+
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/barrier1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="tv_movie_rating,tv_movie_quality,tv_movie_released,tv_movie_runtime" />
+        app:constraint_referenced_ids="tv_movie_rating,tv_movie_quality,tv_movie_released,tv_movie_runtime,tv_movie_content_rating" />
 
     <TextView
         android:id="@+id/tv_movie_genres"

--- a/app/src/main/res/layout/content_tv_show_mobile.xml
+++ b/app/src/main/res/layout/content_tv_show_mobile.xml
@@ -119,10 +119,27 @@
         android:layout_marginEnd="10dp"
         android:textColor="#FFFFFF"
         app:layout_constraintBottom_toTopOf="@id/barrier1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/tv_tv_show_content_rating"
         app:layout_constraintStart_toEndOf="@id/tv_tv_show_released"
         app:layout_constraintTop_toBottomOf="@id/tv_tv_show_title"
         tools:text="# h # min"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/tv_tv_show_content_rating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/barrier1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_tv_show_runtime"
+        app:layout_constraintTop_toBottomOf="@id/tv_tv_show_title"
+        tools:text="TV-14"
         tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Barrier
@@ -130,7 +147,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="tv_tv_show_rating,tv_tv_show_quality,tv_tv_show_released,tv_tv_show_runtime" />
+        app:constraint_referenced_ids="tv_tv_show_rating,tv_tv_show_quality,tv_tv_show_released,tv_tv_show_runtime,tv_tv_show_content_rating" />
 
     <TextView
         android:id="@+id/tv_tv_show_genres"

--- a/app/src/main/res/layout/content_tv_show_tv.xml
+++ b/app/src/main/res/layout/content_tv_show_tv.xml
@@ -100,12 +100,27 @@
         tools:text="# h # min"
         tools:visibility="visible" />
 
+    <TextView
+        android:id="@+id/tv_tv_show_content_rating"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="15dp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/barrier1"
+        app:layout_constraintStart_toEndOf="@id/tv_tv_show_runtime"
+        app:layout_constraintTop_toBottomOf="@id/tv_tv_show_title"
+        tools:text="TV-14"
+        tools:visibility="visible" />
+
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/barrier1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="tv_tv_show_rating,tv_tv_show_quality,tv_tv_show_released,tv_tv_show_runtime" />
+        app:constraint_referenced_ids="tv_tv_show_rating,tv_tv_show_quality,tv_tv_show_released,tv_tv_show_runtime,tv_tv_show_content_rating" />
 
     <TextView
         android:id="@+id/tv_tv_show_genres"

--- a/app/src/main/res/layout/fragment_player_mobile.xml
+++ b/app/src/main/res/layout/fragment_player_mobile.xml
@@ -24,6 +24,25 @@
         app:show_timeout="2000"
         app:surface_type="texture_view" />
 
+    <TextView
+        android:id="@+id/tv_content_rating_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="18dp"
+        android:background="@drawable/bg_content_rating_badge"
+        android:clickable="false"
+        android:focusable="false"
+        android:importantForAccessibility="no"
+        android:textColor="#FFFFFF"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="PG-13"
+        tools:visibility="visible" />
+
     <com.streamflixreborn.streamflix.fragments.player.settings.PlayerSettingsMobileView
         android:id="@+id/settings"
         android:layout_width="300dp"

--- a/app/src/main/res/layout/fragment_player_tv.xml
+++ b/app/src/main/res/layout/fragment_player_tv.xml
@@ -26,6 +26,25 @@
         app:show_timeout="2000"
         app:surface_type="surface_view" />
 
+    <TextView
+        android:id="@+id/tv_content_rating_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="28dp"
+        android:background="@drawable/bg_content_rating_badge"
+        android:clickable="false"
+        android:focusable="false"
+        android:importantForAccessibility="no"
+        android:textColor="#FFFFFF"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="TV-14"
+        tools:visibility="visible" />
+
     <com.streamflixreborn.streamflix.fragments.player.settings.PlayerSettingsTvView
         android:id="@+id/settings"
         android:layout_width="350dp"

--- a/app/src/test/java/com/streamflixreborn/streamflix/models/ContentRatingTest.kt
+++ b/app/src/test/java/com/streamflixreborn/streamflix/models/ContentRatingTest.kt
@@ -1,0 +1,36 @@
+package com.streamflixreborn.streamflix.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ContentRatingTest {
+    @Test fun `movie labels are preserved`() {
+        listOf("G", "PG", "PG-13", "R").forEach { label ->
+            assertEquals(label, ContentRating.create(label, scope = ContentRating.Scope.MOVIE)?.certification)
+        }
+    }
+
+    @Test fun `tv labels are normalized without losing certification`() {
+        mapOf("tv-y" to "TV-Y", " TV-PG " to "TV-PG", "tv_14" to "TV-14", "TV-MA" to "TV-MA")
+            .forEach { (raw, expected) ->
+                assertEquals(expected, ContentRating.create(raw, scope = ContentRating.Scope.SERIES)?.certification)
+            }
+    }
+
+    @Test fun `missing and unrated labels are null`() {
+        listOf(null, "", "  ", "N/A", "Unknown", "NR").forEach { raw ->
+            assertNull(ContentRating.create(raw, scope = ContentRating.Scope.MOVIE))
+        }
+    }
+
+    @Test fun `episode then season then series fallback preserves scope`() {
+        val series = ContentRating.create("TV-PG", scope = ContentRating.Scope.SERIES)
+        val season = ContentRating.create("TV-14", scope = ContentRating.Scope.SEASON)
+        val episode = ContentRating.create("TV-MA", scope = ContentRating.Scope.EPISODE)
+        assertEquals(ContentRating.Scope.EPISODE, ContentRating.mostSpecific(episode, season, series)?.scope)
+        assertEquals(ContentRating.Scope.SEASON, ContentRating.mostSpecific(null, season, series)?.scope)
+        assertEquals(ContentRating.Scope.SERIES, ContentRating.mostSpecific(null, null, series)?.scope)
+        assertNull(ContentRating.mostSpecific(null, null, null))
+    }
+}

--- a/app/src/test/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicyTest.kt
+++ b/app/src/test/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicyTest.kt
@@ -4,6 +4,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class ContentRatingOverlayPolicyTest {
     @Test fun `overlay duration is five seconds`() {
@@ -20,7 +22,37 @@ class ContentRatingOverlayPolicyTest {
         val policy = ContentRatingOverlayPolicy()
         assertTrue(policy.onMediaChanged("episode:A"))
         assertTrue(policy.onMediaChanged("episode:B"))
-        assertFalse(policy.accepts("episode:A"))
-        assertTrue(policy.accepts("episode:B"))
+        assertFalse(policy.publishIfCurrent("episode:A") { error("stale result published") })
+        var published = false
+        assertTrue(policy.publishIfCurrent("episode:B") { published = true })
+        assertTrue(published)
+    }
+
+    @Test fun `media change cannot interleave with validated publication`() {
+        val policy = ContentRatingOverlayPolicy()
+        policy.onMediaChanged("episode:A")
+        val publicationStarted = CountDownLatch(1)
+        val allowPublicationToFinish = CountDownLatch(1)
+        val mediaChangeFinished = CountDownLatch(1)
+        val publisher = Thread {
+            policy.publishIfCurrent("episode:A") {
+                publicationStarted.countDown()
+                allowPublicationToFinish.await(1, TimeUnit.SECONDS)
+            }
+        }
+        val changer = Thread {
+            publicationStarted.await(1, TimeUnit.SECONDS)
+            policy.onMediaChanged("episode:B")
+            mediaChangeFinished.countDown()
+        }
+        publisher.start()
+        changer.start()
+        assertTrue(publicationStarted.await(1, TimeUnit.SECONDS))
+        assertFalse(mediaChangeFinished.await(50, TimeUnit.MILLISECONDS))
+        allowPublicationToFinish.countDown()
+        publisher.join()
+        changer.join()
+        assertTrue(mediaChangeFinished.await(1, TimeUnit.SECONDS))
+        assertFalse(policy.publishIfCurrent("episode:A") { error("stale result published") })
     }
 }

--- a/app/src/test/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicyTest.kt
+++ b/app/src/test/java/com/streamflixreborn/streamflix/utils/ContentRatingOverlayPolicyTest.kt
@@ -1,0 +1,26 @@
+package com.streamflixreborn.streamflix.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ContentRatingOverlayPolicyTest {
+    @Test fun `overlay duration is five seconds`() {
+        assertEquals(5_000L, ContentRatingOverlayPolicy.DISPLAY_DURATION_MS)
+    }
+
+    @Test fun `same media events such as pause and resume do not retrigger`() {
+        val policy = ContentRatingOverlayPolicy()
+        assertTrue(policy.onMediaChanged("movie:A"))
+        assertFalse(policy.onMediaChanged("movie:A"))
+    }
+
+    @Test fun `new episode restarts and old asynchronous result is rejected`() {
+        val policy = ContentRatingOverlayPolicy()
+        assertTrue(policy.onMediaChanged("episode:A"))
+        assertTrue(policy.onMediaChanged("episode:B"))
+        assertFalse(policy.accepts("episode:A"))
+        assertTrue(policy.accepts("episode:B"))
+    }
+}

--- a/app/src/test/java/com/streamflixreborn/streamflix/utils/ContentRatingRepositoryTest.kt
+++ b/app/src/test/java/com/streamflixreborn/streamflix/utils/ContentRatingRepositoryTest.kt
@@ -1,0 +1,12 @@
+package com.streamflixreborn.streamflix.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ContentRatingRepositoryTest {
+    @Test fun `cache preference keys are canonical and distinct`() {
+        assertEquals("EN-US", ContentRatingRepository.preferenceKey(" en_US "))
+        assertEquals("FR-FR", ContentRatingRepository.preferenceKey("fr-fr"))
+        assertEquals("DEFAULT", ContentRatingRepository.preferenceKey(null))
+    }
+}


### PR DESCRIPTION
## Summary

Adds content/age ratings such as `G`, `PG`, `PG-13`, `R`, `TV-PG`, `TV-14`, and `TV-MA` throughout Streamflix.

The feature reuses and extends the existing TMDb age-rating logic so the original certification labels are preserved instead of only reducing them to numeric ages.

## Changes

* Add movie content-rating support
* Add TV show content-rating support
* Support episode-specific ratings when reliable metadata is available
* Fall back from episode → season → series rating when needed
* Preserve certification labels such as `PG-13` and `TV-14`
* Cache rating lookups to avoid unnecessary network requests
* Display ratings on relevant movie/TV metadata screens
* Add a compact content-rating badge to the top-left of the video player
* Show the player badge for 5 seconds when a movie or episode starts
* Automatically fade and hide the badge
* Reset the badge and timer when playback changes to another episode or movie
* Do not re-show the badge on pause/resume, seeking, buffering, or opening playback controls
* Prevent stale rating requests from updating the UI after the current media changes
* Keep the overlay non-focusable and compatible with Android TV DPAD navigation
* Ensure missing or failed rating lookups never interrupt playback

## Player behavior

Examples:

`PG`

`PG-13`

`TV-PG`

`TV-14`

The badge appears in the top-left when playback starts, remains visible for about 5 seconds, then fades away.

For TV episodes, the preferred rating order is:

`Exact episode → Season → TV series`

If no reliable rating is available, no badge is shown.

## Notes

This feature is for content classifications such as `PG-13` and `TV-14`, not IMDb user review scores such as `8.7/10`.

Existing playback, subtitles, providers, watch history, favorites, and TMDb functionality should remain unchanged.
