### PR TITLE
Add configurable domains for German providers

### DIFF
--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsMobileFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsMobileFragment.kt
@@ -232,6 +232,7 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
     private fun displaySettings() {
         updateOverviewLabels()
         updateProviderVisibilityState()
+        bindGenericProviderDomain()
         SupabaseSettingsController.bind(this, lifecycleScope) { key ->
             findPreference(key)
         }
@@ -853,6 +854,81 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
         } ?: getString(R.string.settings_provider_connection_title)
     }
 
+
+    private fun configurableDomainDefault(providerName: String?): String? =
+        when (providerName) {
+            "AniWorld" -> "https://aniworld.to/"
+            "Filmpalast" -> "https://filmpalast.to/"
+            "HDFilme" -> "https://hdfilme.cafe/"
+            "MEGAKino" -> "https://megakino12.com"
+            "Einschalten" -> "https://einschalten.in"
+            else -> null
+        }
+
+    private fun bindGenericProviderDomain() {
+        val provider = UserPreferences.currentProvider ?: return
+        val defaultBaseUrl = configurableDomainDefault(provider.name) ?: return
+
+        findPreference<EditTextPreference>("provider_domain_generic")?.apply {
+            val displayDomain =
+                UserPreferences.providerDomainForDisplay(provider.name, defaultBaseUrl)
+
+            summary = displayDomain
+
+            val customDomain = UserPreferences.getProviderCustomDomain(provider.name)
+            text = customDomain.ifBlank { null }
+
+            setOnBindEditTextListener { editText ->
+                editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI
+                editText.imeOptions = EditorInfo.IME_ACTION_DONE
+                editText.hint = UserPreferences.providerDomainForDisplay(
+                    provider.name,
+                    defaultBaseUrl
+                )
+            }
+
+            setOnPreferenceChangeListener { preference, newValue ->
+                val typed = (newValue as String).trim()
+
+                if (typed.isBlank()) {
+                    UserPreferences.resetProviderCustomDomain(provider.name)
+                } else {
+                    UserPreferences.setProviderCustomDomain(provider.name, typed)
+                }
+
+                preference.summary =
+                    UserPreferences.providerDomainForDisplay(provider.name, defaultBaseUrl)
+
+                ProviderChangeNotifier.notifyProviderChanged()
+
+                true
+            }
+        }
+
+        findPreference<Preference>("provider_domain_generic_reset")
+            ?.setOnPreferenceClickListener {
+                UserPreferences.resetProviderCustomDomain(provider.name)
+
+                findPreference<EditTextPreference>("provider_domain_generic")?.apply {
+                    text = null
+                    summary = UserPreferences.providerDomainForDisplay(
+                        provider.name,
+                        defaultBaseUrl
+                    )
+                }
+
+                ProviderChangeNotifier.notifyProviderChanged()
+
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.settings_provider_domain_reset_done),
+                    Toast.LENGTH_SHORT
+                ).show()
+
+                true
+            }
+    }
+
     private fun updateProviderVisibilityState() {
         val isStreamingCommunity = UserPreferences.currentProvider is StreamingCommunityProvider
         val isSerienStream = UserPreferences.currentProvider is SerienStreamProvider
@@ -860,9 +936,20 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
         val isCuevana = UserPreferences.currentProvider?.name == "Cuevana 3"
         val isPoseidon = UserPreferences.currentProvider?.name == "Poseidonhd2"
         val isAnimeOnlineNinja = UserPreferences.currentProvider is AnimeOnlineNinjaProvider
+        val hasGenericDomain =
+            configurableDomainDefault(UserPreferences.currentProvider?.name) != null
         val hasConfigProvider = UserPreferences.currentProvider is ProviderConfigUrl
-        val hasSpecificOptions = isStreamingCommunity || isCuevana || isPoseidon || isAnimeOnlineNinja
+        val hasSpecificOptions =
+            isStreamingCommunity ||
+                isSerienStream ||
+                isMoflix ||
+                isCuevana ||
+                isPoseidon ||
+                isAnimeOnlineNinja ||
+                hasGenericDomain
 
+        findPreference<PreferenceCategory>("pc_generic_provider_domain_settings")?.isVisible =
+            hasGenericDomain
         findPreference<PreferenceCategory>("pc_streamingcommunity_settings")?.isVisible = isStreamingCommunity
         findPreference<PreferenceCategory>("pc_serienstream_settings")?.isVisible = isSerienStream
         findPreference<PreferenceCategory>("pc_moflix_settings")?.isVisible = isMoflix

--- a/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsTvFragment.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/fragments/settings/SettingsTvFragment.kt
@@ -237,6 +237,7 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
     private fun displaySettings() {
         updateOverviewLabels()
         updateProviderVisibilityState()
+        bindGenericProviderDomain()
         SupabaseSettingsController.bind(this, lifecycleScope) { key ->
             findPreference(key)
         }
@@ -1473,6 +1474,81 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
         } ?: getString(R.string.settings_provider_connection_title)
     }
 
+
+    private fun configurableDomainDefault(providerName: String?): String? =
+        when (providerName) {
+            "AniWorld" -> "https://aniworld.to/"
+            "Filmpalast" -> "https://filmpalast.to/"
+            "HDFilme" -> "https://hdfilme.cafe/"
+            "MEGAKino" -> "https://megakino12.com"
+            "Einschalten" -> "https://einschalten.in"
+            else -> null
+        }
+
+    private fun bindGenericProviderDomain() {
+        val provider = UserPreferences.currentProvider ?: return
+        val defaultBaseUrl = configurableDomainDefault(provider.name) ?: return
+
+        findPreference<EditTextPreference>("provider_domain_generic")?.apply {
+            val displayDomain =
+                UserPreferences.providerDomainForDisplay(provider.name, defaultBaseUrl)
+
+            summary = displayDomain
+
+            val customDomain = UserPreferences.getProviderCustomDomain(provider.name)
+            text = customDomain.ifBlank { null }
+
+            setOnBindEditTextListener { editText ->
+                editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI
+                editText.imeOptions = EditorInfo.IME_ACTION_DONE
+                editText.hint = UserPreferences.providerDomainForDisplay(
+                    provider.name,
+                    defaultBaseUrl
+                )
+            }
+
+            setOnPreferenceChangeListener { preference, newValue ->
+                val typed = (newValue as String).trim()
+
+                if (typed.isBlank()) {
+                    UserPreferences.resetProviderCustomDomain(provider.name)
+                } else {
+                    UserPreferences.setProviderCustomDomain(provider.name, typed)
+                }
+
+                preference.summary =
+                    UserPreferences.providerDomainForDisplay(provider.name, defaultBaseUrl)
+
+                ProviderChangeNotifier.notifyProviderChanged()
+
+                true
+            }
+        }
+
+        findPreference<Preference>("provider_domain_generic_reset")
+            ?.setOnPreferenceClickListener {
+                UserPreferences.resetProviderCustomDomain(provider.name)
+
+                findPreference<EditTextPreference>("provider_domain_generic")?.apply {
+                    text = null
+                    summary = UserPreferences.providerDomainForDisplay(
+                        provider.name,
+                        defaultBaseUrl
+                    )
+                }
+
+                ProviderChangeNotifier.notifyProviderChanged()
+
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.settings_provider_domain_reset_done),
+                    Toast.LENGTH_SHORT
+                ).show()
+
+                true
+            }
+    }
+
     private fun updateProviderVisibilityState() {
         val isStreamingCommunity = UserPreferences.currentProvider is StreamingCommunityProvider
         val isSerienStream = UserPreferences.currentProvider is SerienStreamProvider
@@ -1480,9 +1556,20 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
         val isCuevana = UserPreferences.currentProvider?.name == "Cuevana 3"
         val isPoseidon = UserPreferences.currentProvider?.name == "Poseidonhd2"
         val isAnimeOnlineNinja = UserPreferences.currentProvider is AnimeOnlineNinjaProvider
+        val hasGenericDomain =
+            configurableDomainDefault(UserPreferences.currentProvider?.name) != null
         val hasConfigProvider = UserPreferences.currentProvider is ProviderConfigUrl
-        val hasSpecificOptions = isStreamingCommunity || isCuevana || isPoseidon || isAnimeOnlineNinja
+        val hasSpecificOptions =
+            isStreamingCommunity ||
+                isSerienStream ||
+                isMoflix ||
+                isCuevana ||
+                isPoseidon ||
+                isAnimeOnlineNinja ||
+                hasGenericDomain
 
+        findPreference<PreferenceCategory>("pc_generic_provider_domain_settings")?.isVisible =
+            hasGenericDomain
         findPreference<PreferenceCategory>("pc_streamingcommunity_settings")?.isVisible = isStreamingCommunity
         findPreference<PreferenceCategory>("pc_serienstream_settings")?.isVisible = isSerienStream
         findPreference<PreferenceCategory>("pc_moflix_settings")?.isVisible = isMoflix

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/AniWorldProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/AniWorldProvider.kt
@@ -54,18 +54,56 @@ import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
+import com.streamflixreborn.streamflix.utils.UserPreferences
 
 object AniWorldProvider : Provider {
 
 
-    private const val URL = "https://aniworld.to/"
-    override val baseUrl = URL
+    private const val DEFAULT_BASE_URL = "https://aniworld.to/"
 
     override val name = "AniWorld"
-    override val logo = "$URL/public/img/facebook.jpg"
+
+    override val baseUrl: String
+        get() = UserPreferences.resolveProviderBaseUrl(name, DEFAULT_BASE_URL)
+
+    override val logo: String
+        get() = "${baseUrl.trimEnd('/')}/public/img/facebook.jpg"
     override val language = "de"
 
-    private val service = Service.build()
+    @Volatile
+    private var cachedService: Service? = null
+
+    @Volatile
+    private var cachedServiceBaseUrl: String? = null
+
+    private val service: Service
+        get() {
+            val currentBaseUrl = baseUrl.trimEnd('/') + "/"
+            val currentService = cachedService
+
+            if (currentService != null && cachedServiceBaseUrl == currentBaseUrl) {
+                return currentService
+            }
+
+            return synchronized(this) {
+                val synchronizedService = cachedService
+
+                if (
+                    synchronizedService != null &&
+                    cachedServiceBaseUrl == currentBaseUrl
+                ) {
+                    synchronizedService
+                } else {
+                    Service.build(currentBaseUrl).also {
+                        cachedService = it
+                        cachedServiceBaseUrl = currentBaseUrl
+                    }
+                }
+            }
+        }
+
+    private fun siteUrl(path: String): String =
+        "${baseUrl.trimEnd('/')}/${path.trimStart('/')}"
 
     private var tvShowDao: TvShowDao? = null
     private var isWorkerScheduled = false
@@ -129,7 +167,7 @@ object AniWorldProvider : Provider {
                                 ?.text()
                                 ?: "",
                             poster = it.selectFirst("img")
-                                ?.attr("data-src")?.let { src -> URL + src },
+                                ?.attr("data-src")?.let { src -> siteUrl(src) },
                         )
                     }
             )
@@ -148,7 +186,7 @@ object AniWorldProvider : Provider {
                                 ?.text()
                                 ?: "",
                             poster = it.selectFirst("img")
-                                ?.attr("data-src")?.let { src -> URL + src },
+                                ?.attr("data-src")?.let { src -> siteUrl(src) },
                         )
                     }
             )
@@ -167,7 +205,7 @@ object AniWorldProvider : Provider {
                                 ?.text()
                                 ?: "",
                             poster = it.selectFirst("img")
-                                ?.attr("data-src")?.let { src -> URL + src },
+                                ?.attr("data-src")?.let { src -> siteUrl(src) },
                         )
                     }
             )
@@ -250,11 +288,11 @@ object AniWorldProvider : Provider {
             trailer = document.selectFirst("div[itemprop='trailer'] a")
                 ?.attr("href"),
             poster = document.selectFirst("div.seriesCoverBox img")
-                ?.attr("data-src")?.let { URL + it },
+                ?.attr("data-src")?.let { siteUrl(it) },
             banner = document.selectFirst("#series > section > div.backdrop")
                 ?.attr("style")
                 ?.replace("background-image: url(/", "")?.replace(")", "")
-                ?.let { URL + it },
+                ?.let { siteUrl(it) },
 
 
             seasons = document.select("#stream > ul:nth-child(1) > li")
@@ -375,7 +413,7 @@ object AniWorldProvider : Provider {
                         ?.text()
                         ?: "",
                     poster = it.selectFirst("img")
-                        ?.attr("data-src")?.let { src -> URL + src },
+                        ?.attr("data-src")?.let { src -> siteUrl(src) },
                 )
             }
         )
@@ -402,7 +440,7 @@ object AniWorldProvider : Provider {
                     title = it.selectFirst("h3")
                         ?.text() ?: "",
                     poster = it.selectFirst("img")
-                        ?.attr("data-src")?.let { src -> URL + src },
+                        ?.attr("data-src")?.let { src -> siteUrl(src) },
                 )
             }
         )
@@ -417,7 +455,7 @@ object AniWorldProvider : Provider {
 
         val servers = document.select("div.hosterSiteVideo > ul > li").mapNotNull {
             val redirectUrl = it.selectFirst("a")
-                ?.attr("href")?.let { href -> URL + href }
+                ?.attr("href")?.let { href -> siteUrl(href) }
                 ?: return@mapNotNull null
 
             val name = it.selectFirst("h4")
@@ -561,10 +599,10 @@ object AniWorldProvider : Provider {
                 }
             }
 
-            fun build(): Service {
+            fun build(baseUrl: String): Service {
                 val client = getOkHttpClient()
                 val retrofit = Retrofit.Builder()
-                    .baseUrl(URL)
+                    .baseUrl(baseUrl)
                     .addConverterFactory(JsoupConverterFactory.create())
                     .addConverterFactory(GsonConverterFactory.create())
                     .client(client)
@@ -572,10 +610,10 @@ object AniWorldProvider : Provider {
                 return retrofit.create(Service::class.java)
             }
 
-            fun buildUnsafe(): Service {
+            fun buildUnsafe(baseUrl: String): Service {
                 val client = getUnsafeOkHttpClient()
                 val retrofit = Retrofit.Builder()
-                    .baseUrl(URL)
+                    .baseUrl(baseUrl)
                     .addConverterFactory(JsoupConverterFactory.create())
                     .addConverterFactory(GsonConverterFactory.create())
                     .client(client)
@@ -587,7 +625,7 @@ object AniWorldProvider : Provider {
         @GET(".")
         suspend fun getHome(): Document
 
-        @POST("https://aniworld.to/ajax/search")
+        @POST("ajax/search")
         @FormUrlEncoded
         suspend fun search(@Field("keyword") query: String): List<SearchItem>
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/EinschaltenProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/EinschaltenProvider.kt
@@ -29,11 +29,16 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import org.json.JSONArray
 import java.util.concurrent.TimeUnit
+import com.streamflixreborn.streamflix.utils.UserPreferences
 
 object EinschaltenProvider : Provider {
 
     override val name = "Einschalten"
-    override val baseUrl = "https://einschalten.in"
+
+    private const val DEFAULT_BASE_URL = "https://einschalten.in"
+
+    override val baseUrl: String
+        get() = UserPreferences.resolveProviderBaseUrl(name, DEFAULT_BASE_URL)
     override val logo = "https://images2.imgbox.com/74/12/NBWU0dNi_o.png"
     override val language = "de"
 
@@ -81,7 +86,37 @@ object EinschaltenProvider : Provider {
         ): ResponseBody
     }
 
-    private val service = EinschaltenService.build(baseUrl)
+    @Volatile
+    private var cachedService: EinschaltenService? = null
+
+    @Volatile
+    private var cachedServiceBaseUrl: String? = null
+
+    private val service: EinschaltenService
+        get() {
+            val currentBaseUrl = baseUrl.trimEnd('/') + "/"
+            val currentService = cachedService
+
+            if (currentService != null && cachedServiceBaseUrl == currentBaseUrl) {
+                return currentService
+            }
+
+            return synchronized(this) {
+                val synchronizedService = cachedService
+
+                if (
+                    synchronizedService != null &&
+                    cachedServiceBaseUrl == currentBaseUrl
+                ) {
+                    synchronizedService
+                } else {
+                    EinschaltenService.build(currentBaseUrl).also {
+                        cachedService = it
+                        cachedServiceBaseUrl = currentBaseUrl
+                    }
+                }
+            }
+        }
 
     private suspend fun getPosterUrl(movieId: String, posterPath: String): String {
         if (posterPath.isNotBlank()) {

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/FilmPalastProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/FilmPalastProvider.kt
@@ -33,16 +33,55 @@ import retrofit2.http.Path
 import retrofit2.http.Url
 import java.io.File
 import java.util.concurrent.TimeUnit
+import com.streamflixreborn.streamflix.utils.UserPreferences
 
 object FilmPalastProvider : Provider {
 
-    private val BASE_URL = "https://filmpalast.to/"
-    override val baseUrl = BASE_URL
+    private const val DEFAULT_BASE_URL = "https://filmpalast.to/"
+
     override val name = "Filmpalast"
-    override val logo = "$BASE_URL/themes/downloadarchive/images/logo.png"
+
+    override val baseUrl: String
+        get() = UserPreferences.resolveProviderBaseUrl(name, DEFAULT_BASE_URL)
+
+    override val logo: String
+        get() = "${baseUrl.trimEnd('/')}/themes/downloadarchive/images/logo.png"
     override val language = "de"
 
-    private val service = FilmpalastService.build()
+    @Volatile
+    private var cachedService: FilmpalastService? = null
+
+    @Volatile
+    private var cachedServiceBaseUrl: String? = null
+
+    private val service: FilmpalastService
+        get() {
+            val currentBaseUrl = baseUrl.trimEnd('/') + "/"
+            val currentService = cachedService
+
+            if (currentService != null && cachedServiceBaseUrl == currentBaseUrl) {
+                return currentService
+            }
+
+            return synchronized(this) {
+                val synchronizedService = cachedService
+
+                if (
+                    synchronizedService != null &&
+                    cachedServiceBaseUrl == currentBaseUrl
+                ) {
+                    synchronizedService
+                } else {
+                    FilmpalastService.build(currentBaseUrl).also {
+                        cachedService = it
+                        cachedServiceBaseUrl = currentBaseUrl
+                    }
+                }
+            }
+        }
+
+    private fun siteUrl(path: String): String =
+        "${baseUrl.trimEnd('/')}/${path.trimStart('/')}"
 
     override suspend fun getHome(): List<Category> {
         val document = service.getHome()
@@ -54,7 +93,7 @@ object FilmPalastProvider : Provider {
                     val id = href.substringAfterLast("/")
                     val posterSrc = li.select("a img").attr("src")
                     val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                        "https://filmpalast.to$posterSrc"
+                        siteUrl(posterSrc)
                     } else {
                         posterSrc
                     }
@@ -88,7 +127,7 @@ object FilmPalastProvider : Provider {
             val posterSrc = article.selectFirst("a img")?.attr("src") ?: ""
 
             val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                "https://filmpalast.to$posterSrc"
+                siteUrl(posterSrc)
             } else {
                 posterSrc
             }
@@ -111,7 +150,7 @@ object FilmPalastProvider : Provider {
             val posterSrc = article.selectFirst("a img")?.attr("src") ?: ""
 
             val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                "https://filmpalast.to$posterSrc"
+                siteUrl(posterSrc)
             } else {
                 posterSrc
             }
@@ -162,7 +201,7 @@ object FilmPalastProvider : Provider {
             val posterSrc = article.selectFirst("a img")?.attr("src") ?: ""
 
             val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                "https://filmpalast.to$posterSrc"
+                siteUrl(posterSrc)
             } else {
                 posterSrc
             }
@@ -205,11 +244,11 @@ object FilmPalastProvider : Provider {
 
 
     override suspend fun getMovie(id: String): Movie {
-        val relativeId = BASE_URL + "stream/" + id;
+        val relativeId = siteUrl("stream/$id");
         val document = service.getMoviePage(relativeId)
         val title = document.selectFirst("h2")?.text() ?: ""
         val poster = document.selectFirst("img.cover2")?.attr("src")?.let {
-            if (it.startsWith("http")) it else "${BASE_URL.removeSuffix("/")}$it"
+            if (it.startsWith("http")) it else siteUrl(it)
         }
         val description = document.selectFirst("span[itemprop=description]")?.text()
         val rating = document.selectFirst("div#star-rate")?.attr("data-rating")?.toDoubleOrNull()
@@ -245,7 +284,7 @@ object FilmPalastProvider : Provider {
     }
 
     override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
-        val relativeId = BASE_URL + "stream/" + id;
+        val relativeId = siteUrl("stream/$id");
         val document = service.getMoviePage(relativeId)
         val servers = mutableListOf<Video.Server>()
 
@@ -306,7 +345,7 @@ object FilmPalastProvider : Provider {
             val posterSrc = article.selectFirst("a img")?.attr("src") ?: ""
 
             val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                "https://filmpalast.to$posterSrc"
+                siteUrl(posterSrc)
             } else {
                 posterSrc
             }
@@ -333,7 +372,7 @@ object FilmPalastProvider : Provider {
             val posterSrc = article.selectFirst("a img")?.attr("src") ?: ""
 
             val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                "https://filmpalast.to$posterSrc"
+                siteUrl(posterSrc)
             } else {
                 posterSrc
             }
@@ -353,11 +392,11 @@ object FilmPalastProvider : Provider {
     }
 
     override suspend fun getTvShow(id: String): TvShow {
-        val relativeId = BASE_URL + "stream/" + id
+        val relativeId = siteUrl("stream/$id")
         val document = service.getTvShow(relativeId)
         val title = document.selectFirst("h2")?.text() ?: ""
         val poster = document.selectFirst("img.cover2")?.attr("src")?.let {
-            if (it.startsWith("http")) it else "${BASE_URL.removeSuffix("/")}$it"
+            if (it.startsWith("http")) it else siteUrl(it)
         }
         val description = document.selectFirst("span[itemprop=description]")?.text()
         val rating = document.selectFirst("div#star-rate")?.attr("data-rating")?.toDoubleOrNull()
@@ -441,7 +480,7 @@ object FilmPalastProvider : Provider {
 
             val posterSrc = article.selectFirst("a img")?.attr("src").orEmpty()
             val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                "https://filmpalast.to$posterSrc"
+                siteUrl(posterSrc)
             } else {
                 posterSrc
             }
@@ -473,7 +512,7 @@ object FilmPalastProvider : Provider {
         val showId = parts[0]
         val seasonNumber = parts[1].toIntOrNull() ?: return emptyList()
         
-        val relativeId = BASE_URL + "stream/" + showId
+        val relativeId = siteUrl("stream/$showId")
         val document = service.getTvShow(relativeId)
         val title = document.selectFirst("h2")?.text() ?: ""
 
@@ -517,11 +556,11 @@ object FilmPalastProvider : Provider {
         return episodes
     }
     override suspend fun getPeople(id: String, page: Int): People {
-        val url = "$BASE_URL/search/title/$id"
+        val url = siteUrl("search/title/$id")
         val document = service.getPeoplePage(url)
         val name = document.selectFirst("h1")?.text() ?: ""
         val image = document.selectFirst("img.cover2")?.attr("src")?.let {
-            if (it.startsWith("http")) it else "${BASE_URL.removeSuffix("/")}$it"
+            if (it.startsWith("http")) it else siteUrl(it)
         }
         
         // Parse filmography (same structure as movies/series)
@@ -531,7 +570,7 @@ object FilmPalastProvider : Provider {
             val posterSrc = article.selectFirst("a img")?.attr("src") ?: ""
 
             val fullPosterUrl = if (posterSrc.startsWith("/")) {
-                "https://filmpalast.to$posterSrc"
+                siteUrl(posterSrc)
             } else {
                 posterSrc
             }
@@ -600,9 +639,9 @@ object FilmPalastProvider : Provider {
                 return clientToReturn
             }
 
-            fun build(): FilmpalastService {
+            fun build(baseUrl: String): FilmpalastService {
                 val client = getOkHttpClient()
-                val retrofit = Retrofit.Builder().baseUrl(BASE_URL)
+                val retrofit = Retrofit.Builder().baseUrl(baseUrl)
                     .addConverterFactory(JsoupConverterFactory.create())
                     .addConverterFactory(GsonConverterFactory.create()).client(client).build()
                 return retrofit.create(FilmpalastService::class.java)

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/HDFilmeProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/HDFilmeProvider.kt
@@ -35,11 +35,16 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Url
 import retrofit2.http.Path
+import com.streamflixreborn.streamflix.utils.UserPreferences
 
 object HDFilmeProvider : Provider {
 
     override val name: String = "HDFilme"
-    override val baseUrl: String = "https://hdfilme.win"
+
+    private const val DEFAULT_BASE_URL = "https://hdfilme.cafe/"
+
+    override val baseUrl: String
+        get() = UserPreferences.resolveProviderBaseUrl(name, DEFAULT_BASE_URL)
     override val logo: String = "$baseUrl/templates/hdfilme/images/apple-touch-icon.png"
     override val language: String = "de"
 
@@ -126,7 +131,37 @@ object HDFilmeProvider : Provider {
 
     }
 
-    private val service = HDFilmeService.build(baseUrl)
+    @Volatile
+    private var cachedService: HDFilmeService? = null
+
+    @Volatile
+    private var cachedServiceBaseUrl: String? = null
+
+    private val service: HDFilmeService
+        get() {
+            val currentBaseUrl = baseUrl.trimEnd('/') + "/"
+            val currentService = cachedService
+
+            if (currentService != null && cachedServiceBaseUrl == currentBaseUrl) {
+                return currentService
+            }
+
+            return synchronized(this) {
+                val synchronizedService = cachedService
+
+                if (
+                    synchronizedService != null &&
+                    cachedServiceBaseUrl == currentBaseUrl
+                ) {
+                    synchronizedService
+                } else {
+                    HDFilmeService.build(currentBaseUrl).also {
+                        cachedService = it
+                        cachedServiceBaseUrl = currentBaseUrl
+                    }
+                }
+            }
+        }
     private data class SitemapEntry(val url: String, val searchableSlug: String)
 
     @Volatile private var sitemapEntries: List<SitemapEntry>? = null

--- a/app/src/main/java/com/streamflixreborn/streamflix/providers/MEGAKinoProvider.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/providers/MEGAKinoProvider.kt
@@ -30,11 +30,16 @@ import java.util.concurrent.TimeUnit
 
 import MyCookieJar
 import com.streamflixreborn.streamflix.utils.TmdbUtils
+import com.streamflixreborn.streamflix.utils.UserPreferences
 
 object MEGAKinoProvider : Provider {
 
     override val name = "MEGAKino"
-    override val baseUrl = "https://megakino12.com"
+
+    private const val DEFAULT_BASE_URL = "https://megakino12.com"
+
+    override val baseUrl: String
+        get() = UserPreferences.resolveProviderBaseUrl(name, DEFAULT_BASE_URL)
     override val logo = "https://images2.imgbox.com/a2/83/OubSojBq_o.png"
     override val language = "de"
 
@@ -95,7 +100,37 @@ object MEGAKinoProvider : Provider {
         }
     }
 
-    private val service = MEGAKinoService.build(baseUrl)
+    @Volatile
+    private var cachedService: MEGAKinoService? = null
+
+    @Volatile
+    private var cachedServiceBaseUrl: String? = null
+
+    private val service: MEGAKinoService
+        get() {
+            val currentBaseUrl = baseUrl.trimEnd('/') + "/"
+            val currentService = cachedService
+
+            if (currentService != null && cachedServiceBaseUrl == currentBaseUrl) {
+                return currentService
+            }
+
+            return synchronized(this) {
+                val synchronizedService = cachedService
+
+                if (
+                    synchronizedService != null &&
+                    cachedServiceBaseUrl == currentBaseUrl
+                ) {
+                    synchronizedService
+                } else {
+                    MEGAKinoService.build(currentBaseUrl).also {
+                        cachedService = it
+                        cachedServiceBaseUrl = currentBaseUrl
+                    }
+                }
+            }
+        }
 
     private var lastTokenTime = 0L
 

--- a/app/src/main/java/com/streamflixreborn/streamflix/utils/UserPreferences.kt
+++ b/app/src/main/java/com/streamflixreborn/streamflix/utils/UserPreferences.kt
@@ -38,6 +38,7 @@ object UserPreferences {
     const val PROVIDER_AUTOUPDATE = "AUTOUPDATE_URL"
     const val PROVIDER_NEW_INTERFACE = "NEW_INTERFACE"
     const val PROVIDER_PREFERRED_SERVER = "PREFERRED_SERVER"
+    const val PROVIDER_CUSTOM_DOMAIN = "CUSTOM_DOMAIN"
 
     lateinit var providerCache: JSONObject
 
@@ -105,6 +106,83 @@ object UserPreferences {
             providerCache.remove(providerName)
             Key.PROVIDER_CACHE.setString(providerCache.toString())
         }
+    }
+
+    private fun getProviderCache(providerName: String, key: String): String {
+        return providerCache
+            .optJSONObject(providerName)
+            ?.optString(key)
+            .orEmpty()
+    }
+
+    private fun setProviderCache(providerName: String, key: String, value: String) {
+        val innerJson = providerCache.optJSONObject(providerName)
+            ?: JSONObject().also { providerCache.put(providerName, it) }
+
+        innerJson.put(key, value)
+        Key.PROVIDER_CACHE.setString(providerCache.toString())
+    }
+
+    fun getProviderCustomDomain(providerName: String): String =
+        getProviderCache(providerName, PROVIDER_CUSTOM_DOMAIN)
+
+    fun setProviderCustomDomain(providerName: String, value: String) {
+        setProviderCache(
+            providerName,
+            PROVIDER_CUSTOM_DOMAIN,
+            normalizeProviderDomain(value)
+        )
+    }
+
+    fun resetProviderCustomDomain(providerName: String) {
+        setProviderCache(providerName, PROVIDER_CUSTOM_DOMAIN, "")
+    }
+
+    fun resolveProviderBaseUrl(
+        providerName: String,
+        defaultBaseUrl: String
+    ): String {
+        val customDomain = getProviderCustomDomain(providerName)
+        if (customDomain.isBlank()) return defaultBaseUrl
+
+        return runCatching {
+            val uri = android.net.Uri.parse(defaultBaseUrl)
+            uri.buildUpon()
+                .authority(customDomain)
+                .build()
+                .toString()
+        }.getOrDefault(defaultBaseUrl)
+    }
+
+    fun providerDomainForDisplay(
+        providerName: String,
+        defaultBaseUrl: String
+    ): String {
+        val customDomain = getProviderCustomDomain(providerName)
+        if (customDomain.isNotBlank()) return customDomain
+
+        return runCatching {
+            android.net.Uri.parse(defaultBaseUrl).authority.orEmpty()
+        }.getOrDefault(defaultBaseUrl)
+    }
+
+    private fun normalizeProviderDomain(value: String): String {
+        val trimmed = value.trim().trimEnd('/')
+        if (trimmed.isBlank()) return ""
+
+        val withScheme =
+            if (trimmed.contains("://")) trimmed
+            else "https://$trimmed"
+
+        return runCatching {
+            android.net.Uri.parse(withScheme).authority.orEmpty()
+        }.getOrDefault(trimmed)
+            .ifBlank {
+                trimmed
+                    .removePrefix("https://")
+                    .removePrefix("http://")
+                    .substringBefore('/')
+            }
     }
 
     var currentLanguage: String?

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -244,6 +244,12 @@
     <string name="settings_category_network_title">Verbindung und Dienste</string>
     <string name="settings_category_provider_title">Anbietereinstellungen</string>
     <string name="settings_category_provider_url">Haupt-URL</string>
+    <string name="settings_category_provider_domain">Anbieter-Domain</string>
+    <string name="settings_provider_domain">Domain</string>
+    <string name="settings_provider_domain_summary">Domain des Anbieters ändern, wenn die Webseite auf eine neue Adresse wechselt.</string>
+    <string name="settings_provider_domain_reset">Domain zurücksetzen</string>
+    <string name="settings_provider_domain_reset_summary">Die Standard-Domain des Anbieters wiederherstellen.</string>
+    <string name="settings_provider_domain_reset_done">Anbieter-Domain wurde auf den Standard zurückgesetzt.</string>
     <string name="settings_category_provider_update_url">Portal-URL</string>
     <string name="settings_autoupdate">Haupt-URL beim Start aktualisieren</string>
     <string name="settings_autoupdate_on">An</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -301,6 +301,12 @@
     <string name="settings_provider_no_options_title">No provider options available</string>
     <string name="settings_provider_no_options_summary">This provider does not expose any extra configuration right now.</string>
     <string name="settings_category_provider_url">Main URL</string>
+    <string name="settings_category_provider_domain">Provider domain</string>
+    <string name="settings_provider_domain">Domain</string>
+    <string name="settings_provider_domain_summary">Override the provider domain if the website moves to a new address.</string>
+    <string name="settings_provider_domain_reset">Reset domain</string>
+    <string name="settings_provider_domain_reset_summary">Restore the provider default domain.</string>
+    <string name="settings_provider_domain_reset_done">Provider domain reset to default.</string>
     <string name="settings_category_provider_url_manual">Enter manually</string>
     <string name="settings_category_provider_update_url">Portal URL</string>
     <string name="settings_autoupdate">Refresh main URL on startup</string>

--- a/app/src/main/res/xml/settings_mobile.xml
+++ b/app/src/main/res/xml/settings_mobile.xml
@@ -294,6 +294,24 @@
                 app:iconSpaceReserved="false" />
         </PreferenceCategory>
 
+
+        <PreferenceCategory
+            android:key="pc_generic_provider_domain_settings"
+            android:title="@string/settings_category_provider_domain">
+
+            <EditTextPreference
+                android:key="provider_domain_generic"
+                android:title="@string/settings_provider_domain"
+                android:summary="@string/settings_provider_domain_summary"
+                android:inputType="textUri" />
+
+            <Preference
+                android:key="provider_domain_generic_reset"
+                android:title="@string/settings_provider_domain_reset"
+                android:summary="@string/settings_provider_domain_reset_summary" />
+
+        </PreferenceCategory>
+
         <PreferenceCategory
             android:key="pc_streamingcommunity_settings"
             android:title="@string/settings_category_streamingcommunity"

--- a/app/src/main/res/xml/settings_tv.xml
+++ b/app/src/main/res/xml/settings_tv.xml
@@ -241,6 +241,24 @@
                 android:summaryOff="@string/settings_frenchstream_use_new_interface_off" />
         </PreferenceCategory>
 
+
+        <PreferenceCategory
+            android:key="pc_generic_provider_domain_settings"
+            android:title="@string/settings_category_provider_domain">
+
+            <EditTextPreference
+                android:key="provider_domain_generic"
+                android:title="@string/settings_provider_domain"
+                android:summary="@string/settings_provider_domain_summary"
+                android:inputType="textUri" />
+
+            <Preference
+                android:key="provider_domain_generic_reset"
+                android:title="@string/settings_provider_domain_reset"
+                android:summary="@string/settings_provider_domain_reset_summary" />
+
+        </PreferenceCategory>
+
         <PreferenceCategory
             android:key="pc_streamingcommunity_settings"
             android:title="@string/settings_category_streamingcommunity">


### PR DESCRIPTION
This PR adds configurable domains for the main German providers.

Included providers:
- AniWorld
- FilmPalast
- HDFilme
- MEGAKino
- Einschalten

Changes:
- Replace fixed provider domains with configurable domains
- Keep sensible default domains
- Normalize manually entered domains
- Use the selected domain for provider requests, redirects and generated links
- Add TV and mobile settings for changing/resetting provider domains

Notes:
- This PR is independent
- PR2 builds on top of this PR

Validation:
- Kotlin compile successful
- git diff --check clean